### PR TITLE
docs(README): add documentation link and Netlify badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 <p align="center">
   ODS Charts provides Orange Charts components to developers.
   <br>
+  <a href="https://ods-charts.netlify.app/"><strong>Visit ODS Charts documentation</strong></a>
+  <br>
   <br>
   <a href="https://github.com/Orange-OpenSource/ods-charts/issues/new?assignees=-&labels=bug&template=bug_report.yml">Report bug</a>
   ·
@@ -12,6 +14,7 @@
 ## Table of contents
 
 - [Quick start](#quick-start)
+- [Status](#status)
 - [Bugs and feature requests](#bugs-and-feature-requests)
 - [Contributing](#contributing)
 - [Versioning](#versioning)
@@ -23,6 +26,13 @@ Several quick start options are available:
 
 - Clone the repo: `git clone https://github.com/Orange-OpenSource/ods-charts.git`
 - Install with [npm](https://www.npmjs.com/): `npm install ods-charts`
+
+Read the [documentation](https://ods-charts.netlify.app/) for information on the library content and examples.
+
+## Status
+
+[![Netlify Status](https://api.netlify.com/api/v1/badges/3df609fb-4f36-4c09-ba31-284e261f2d8d/deploy-status)](https://app.netlify.com/sites/ods-charts/deploys)
+[![npm version](https://img.shields.io/npm/v/ods-charts?logo=npm&logoColor=fff)](https://www.npmjs.com/package/ods-charts)
 
 ## Bugs and feature requests
 


### PR DESCRIPTION
### Description

This PR adds https://ods-charts.netlify.app/ in our README for the users to have access to our documentation.
This PR also adds the Netlify badge showing the status of the _main_ branch deployment, and the npm badge showing the latest released version.