### PR TITLE
chore: add Dependabot rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,70 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "12:00"
+      timezone: Europe/Paris
+  - package-ecosystem: npm
+    directory: "/"
+    reviewers:
+      - julien-deramond
+    labels:
+      - dependencies
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "12:00"
+      timezone: Europe/Paris
+    versioning-strategy: increase
+    rebase-strategy: disabled
+  - package-ecosystem: npm
+    directory: "/test/angular-ngx-echarts"
+    labels:
+      - dependencies
+    schedule:
+      interval: monthly
+    versioning-strategy: increase
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+  - package-ecosystem: npm
+    directory: "/test/angular-tour-of-heroes"
+    labels:
+      - dependencies
+    schedule:
+      interval: monthly
+    versioning-strategy: increase
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+  - package-ecosystem: npm
+    directory: "/test/react"
+    labels:
+      - dependencies
+    schedule:
+      interval: monthly
+    versioning-strategy: increase
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+  - package-ecosystem: npm
+    directory: "/test/vue"
+    labels:
+      - dependencies
+    schedule:
+      interval: monthly
+    versioning-strategy: increase
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"


### PR DESCRIPTION
### Description

This PR adds a rule for Dependabot:
- each week, the dependencies will be checked for the library
- each month, the dependencies will be checked for each `/test/*` sub-project and the PR should group the updates

This second part is based on [the group rule used by Bootstrap Examples](https://raw.githubusercontent.com/twbs/examples/b2c5286e5e36e33e5655a7e9193c6d224d7f03af/.github/dependabot.yml). I've never tried something like it so let's see if it works once it's merged!