### PR TITLE
fix(test): In the third graph of the test test/html/, a legend is displayed under the title

### DIFF
--- a/test/html/index.html
+++ b/test/html/index.html
@@ -73,6 +73,7 @@
       chart3.setOption(
         lineChartODSTheme
           .setDataOptions({
+            legend: { show: false },
             title: {
               text: 'ECharts Getting Started Example with theme manager',
             },


### PR DESCRIPTION
### Description

In the second graph of the test/html/ test, a legend is displayed under the graph title

![image](https://github.com/Orange-OpenSource/ods-charts/assets/40755890/e3dceb8e-84c3-4a8d-8d8c-02c583b657ef)

This legend is not necessary for a chart with one bar

### Types of change
- Bug fix (non-breaking which fixes an issue)


### Test checklist

Please check that the following tests projects are still working:

- (NA) `docs/examples`
- (NA) `test/angular`
- (NA) `test/angular-tour-of-heroes`
- [X] `test/html`
- (NA) `test/react`
- (NA) `test/vue`
- (NA) `test/examples/bar-line-chart`
- (NA) `test/examples/single-line-chart`

