### PR TITLE
fix(lib): 'ODSCHarts*' → 'ODSCharts*' typo

### DIFF
--- a/docs/examples/index.js
+++ b/docs/examples/index.js
@@ -160,23 +160,23 @@ function generateConfigurator(id, cssThemeName) {
               <label for="colorSetInput" class="form-label">Categorical Color</label>
               <select class="form-select" aria-label="Color set" id="colorSetInput" onchange="changeTheme('${id}')">
                 <option value="${
-                  ODSCharts.ODSCHartsCategoricalColorsSet
+                  ODSCharts.ODSChartsCategoricalColorsSet
                     .DEFAULT_SUPPORTING_COLORS
                 }" >Default supporting colours</option>
                 <option value="${
-                  ODSCharts.ODSCHartsCategoricalColorsSet.LIGHTER_TINTS
+                  ODSCharts.ODSChartsCategoricalColorsSet.LIGHTER_TINTS
                 }" >Lighter tints</option>
                 <option value="${
-                  ODSCharts.ODSCHartsCategoricalColorsSet.DARKER_TINTS
+                  ODSCharts.ODSChartsCategoricalColorsSet.DARKER_TINTS
                 }">Darker tints</option>
                 <option value="${
-                  ODSCharts.ODSCHartsCategoricalColorsSet.SEQUENTIAL_BLUE
+                  ODSCharts.ODSChartsCategoricalColorsSet.SEQUENTIAL_BLUE
                 }">Blue</option>
                 <option value="${
-                  ODSCharts.ODSCHartsCategoricalColorsSet.SEQUENTIAL_GREEN
+                  ODSCharts.ODSChartsCategoricalColorsSet.SEQUENTIAL_GREEN
                 }">Green</option>
                 <option value="${
-                  ODSCharts.ODSCHartsCategoricalColorsSet.SEQUENTIAL_PURPLE
+                  ODSCharts.ODSChartsCategoricalColorsSet.SEQUENTIAL_PURPLE
                 }">Purple</option>
               </select>
             </div>
@@ -479,10 +479,10 @@ var themeManager = ODSCharts.getThemeManager({
   },
   categoricalColors: ${
     'string' === typeof themeManager.options.categoricalColors
-      ? 'ODSCharts.ODSCHartsCategoricalColorsSet.' +
-        Object.keys(ODSCharts.ODSCHartsCategoricalColorsSet).find(
+      ? 'ODSCharts.ODSChartsCategoricalColorsSet.' +
+        Object.keys(ODSCharts.ODSChartsCategoricalColorsSet).find(
           (key) =>
-            ODSCharts.ODSCHartsCategoricalColorsSet[key] ===
+            ODSCharts.ODSChartsCategoricalColorsSet[key] ===
             themeManager.options.categoricalColors
         )
       : `[
@@ -490,10 +490,10 @@ var themeManager = ODSCharts.getThemeManager({
         'string' === typeof color
           ? JSON.stringify(color)
           : `{"colorPalette": ${
-              'ODSCharts.ODSCHartsCategoricalColorsSet.' +
-              Object.keys(ODSCharts.ODSCHartsCategoricalColorsSet).find(
+              'ODSCharts.ODSChartsCategoricalColorsSet.' +
+              Object.keys(ODSCharts.ODSChartsCategoricalColorsSet).find(
                 (key) =>
-                  ODSCharts.ODSCHartsCategoricalColorsSet[key] ===
+                  ODSCharts.ODSChartsCategoricalColorsSet[key] ===
                   color.colorPalette
               )
             }, "colorIndex": ${color.colorIndex}}`
@@ -502,10 +502,10 @@ var themeManager = ODSCharts.getThemeManager({
     ]`
   },
   visualMapColor:  ${
-    'ODSCharts.ODSCHartsSequentialColorsSet.' +
-    Object.keys(ODSCharts.ODSCHartsSequentialColorsSet).find(
+    'ODSCharts.ODSChartsSequentialColorsSet.' +
+    Object.keys(ODSCharts.ODSChartsSequentialColorsSet).find(
       (key) =>
-        ODSCharts.ODSCHartsSequentialColorsSet[key] ===
+        ODSCharts.ODSChartsSequentialColorsSet[key] ===
         themeManager.options.visualMapColor
     )
   },
@@ -598,10 +598,10 @@ myChart.setOption(themeManager.getChartOptions());
           'string' === typeof color
             ? JSON.stringify(color)
             : `{"colorPalette": ${
-                'ODSCharts.ODSCHartsCategoricalColorsSet.' +
-                Object.keys(ODSCharts.ODSCHartsCategoricalColorsSet).find(
+                'ODSCharts.ODSChartsCategoricalColorsSet.' +
+                Object.keys(ODSCharts.ODSChartsCategoricalColorsSet).find(
                   (key) =>
-                    ODSCharts.ODSCHartsCategoricalColorsSet[key] ===
+                    ODSCharts.ODSChartsCategoricalColorsSet[key] ===
                     color.colorPalette
                 )
               }, "colorIndex": ${color.colorIndex}}`
@@ -803,7 +803,7 @@ window.generateSingleLineChart = async (id) => {
     id,
     option,
     undefined,
-    ODSCharts.ODSCHartsCategoricalColorsSet.SEQUENTIAL_PURPLE
+    ODSCharts.ODSChartsCategoricalColorsSet.SEQUENTIAL_PURPLE
   );
 };
 
@@ -825,7 +825,7 @@ window.generateMultipleLineChart = async (id) => {
     id,
     option,
     undefined,
-    ODSCharts.ODSCHartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS,
+    ODSCharts.ODSChartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS,
     undefined,
     ODSCharts.ODSChartsLineStyle.BROKEN
   );
@@ -881,28 +881,28 @@ window.generateBarChart = async (
     stacked
       ? [
           {
-            colorPalette: ODSCharts.ODSCHartsCategoricalColorsSet.DARKER_TINTS,
+            colorPalette: ODSCharts.ODSChartsCategoricalColorsSet.DARKER_TINTS,
             colorIndex: 0,
           },
           {
             colorPalette:
-              ODSCharts.ODSCHartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS,
+              ODSCharts.ODSChartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS,
             colorIndex: 0,
           },
           {
-            colorPalette: ODSCharts.ODSCHartsCategoricalColorsSet.LIGHTER_TINTS,
+            colorPalette: ODSCharts.ODSChartsCategoricalColorsSet.LIGHTER_TINTS,
             colorIndex: 0,
           },
         ]
       : grouped
       ? [
           {
-            colorPalette: ODSCharts.ODSCHartsCategoricalColorsSet.DARKER_TINTS,
+            colorPalette: ODSCharts.ODSChartsCategoricalColorsSet.DARKER_TINTS,
             colorIndex: 0,
           },
           {
             colorPalette:
-              ODSCharts.ODSCHartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS,
+              ODSCharts.ODSChartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS,
             colorIndex: 0,
           },
         ]
@@ -910,14 +910,14 @@ window.generateBarChart = async (
       ? [
           {
             colorPalette:
-              ODSCharts.ODSCHartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS,
+              ODSCharts.ODSChartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS,
             colorIndex: 1,
           },
         ]
       : [
           {
             colorPalette:
-              ODSCharts.ODSCHartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS,
+              ODSCharts.ODSChartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS,
             colorIndex: 3,
           },
         ]
@@ -952,7 +952,7 @@ window.generateDatasetBarChart = async (id) => {
     id,
     option,
     undefined,
-    ODSCharts.ODSCHartsCategoricalColorsSet.DARKER_TINTS
+    ODSCharts.ODSChartsCategoricalColorsSet.DARKER_TINTS
   );
 };
 
@@ -993,33 +993,33 @@ window.generateBarLineChart = async (
     id,
     option,
     undefined,
-    //ODSCharts.ODSCHartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS
+    //ODSCharts.ODSChartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS
     grouped
       ? [
           {
             colorPalette:
-              ODSCharts.ODSCHartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS,
+              ODSCharts.ODSChartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS,
             colorIndex: 1,
           },
           {
-            colorPalette: ODSCharts.ODSCHartsCategoricalColorsSet.LIGHTER_TINTS,
+            colorPalette: ODSCharts.ODSChartsCategoricalColorsSet.LIGHTER_TINTS,
             colorIndex: 1,
           },
           {
             colorPalette:
-              ODSCharts.ODSCHartsCategoricalColorsSet.SEQUENTIAL_PURPLE,
+              ODSCharts.ODSChartsCategoricalColorsSet.SEQUENTIAL_PURPLE,
             colorIndex: 0,
           },
         ]
       : [
           {
             colorPalette:
-              ODSCharts.ODSCHartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS,
+              ODSCharts.ODSChartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS,
             colorIndex: 2,
           },
           {
             colorPalette:
-              ODSCharts.ODSCHartsCategoricalColorsSet.SEQUENTIAL_GREEN,
+              ODSCharts.ODSChartsCategoricalColorsSet.SEQUENTIAL_GREEN,
             colorIndex: 0,
           },
         ],

--- a/src/theme/ods-chart-theme.ts
+++ b/src/theme/ods-chart-theme.ts
@@ -49,7 +49,7 @@ import {
   ODSChartsPopoverManagers,
 } from './popover/ods-chart-popover-definitions';
 
-export enum ODSCHartsCategoricalColorsSet {
+export enum ODSChartsCategoricalColorsSet {
   DEFAULT_SUPPORTING_COLORS = 'supportingColors',
   DARKER_TINTS = 'darkerTints',
   LIGHTER_TINTS = 'lighterTints',
@@ -59,40 +59,40 @@ export enum ODSCHartsCategoricalColorsSet {
 }
 
 /**
- * ODSCHartsCustomCategoricalColor is used to define a color.
+ * ODSChartsCustomCategoricalColor is used to define a color.
  *
  * - It can be the string value of the color
  *
- * - Or it can be a {@link ODSCHartsCategoricalColor} to reference a color of one predefined set of Orange Design System colors.
+ * - Or it can be a {@link ODSChartsCategoricalColor} to reference a color of one predefined set of Orange Design System colors.
  *
  * example
  * ```
  * {
- *  colorPalette: ODSCharts.ODSCHartsCategoricalColorsSet.DARKER_TINTS,
+ *  colorPalette: ODSCharts.ODSChartsCategoricalColorsSet.DARKER_TINTS,
  *  colorIndex: 0,
  * }
  * ```
  */
-export type ODSCHartsCustomCategoricalColor =
-  | ODSCHartsCategoricalColor
+export type ODSChartsCustomCategoricalColor =
+  | ODSChartsCategoricalColor
   | string;
 
 /**
- * ODSCHartsCategoricalColor is a color extract from one set of color of Orange Design System.
+ * ODSChartsCategoricalColor is a color extract from one set of color of Orange Design System.
  */
-export interface ODSCHartsCategoricalColor {
+export interface ODSChartsCategoricalColor {
   /**
-   * The {@link ODSCHartsCategoricalColorsSet} to be used to extract a specific color.
-   * (example {@link ODSCHartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS})
+   * The {@link ODSChartsCategoricalColorsSet} to be used to extract a specific color.
+   * (example {@link ODSChartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS})
    */
-  colorPalette: ODSCHartsCategoricalColorsSet;
+  colorPalette: ODSChartsCategoricalColorsSet;
   /**
-   * Index of the color in the {@link ODSCHartsCategoricalColorsSet}
+   * Index of the color in the {@link ODSChartsCategoricalColorsSet}
    */
   colorIndex: number;
 }
 
-export enum ODSCHartsSequentialColorsSet {
+export enum ODSChartsSequentialColorsSet {
   SEQUENTIAL_BLUE = 'blue',
   SEQUENTIAL_GREEN = 'green',
   SEQUENTIAL_PURPLE = 'purple',
@@ -120,39 +120,39 @@ export interface ODSChartsThemeOptions {
    * categoricalColors is the set of colors to be used to graph the chart.
    *
    * It can be
-   * - one of the predefined {@link ODSCHartsCategoricalColorsSet} defined in Orange Design System
+   * - one of the predefined {@link ODSChartsCategoricalColorsSet} defined in Orange Design System
    *
-   * example: `ODSCharts.ODSCHartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS`.
+   * example: `ODSCharts.ODSChartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS`.
    *
-   * - Or it can be an array of colors {@link ODSCHartsCustomCategoricalColor}
+   * - Or it can be an array of colors {@link ODSChartsCustomCategoricalColor}
    *
    * example:
    * ```
    *      [
    *        {
    *          colorPalette:
-   *            ODSCharts.ODSCHartsCategoricalColorsSet
+   *            ODSCharts.ODSChartsCategoricalColorsSet
    *              .DEFAULT_SUPPORTING_COLORS,
    *          colorIndex: 2,
    *        },
    *        {
    *          colorPalette:
-   *            ODSCharts.ODSCHartsCategoricalColorsSet.SEQUENTIAL_GREEN,
+   *            ODSCharts.ODSChartsCategoricalColorsSet.SEQUENTIAL_GREEN,
    *          colorIndex: 0,
    *        },
    *      ]
    * ```
-   * Default categoricalColors is {@link ODSCHartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS}
+   * Default categoricalColors is {@link ODSChartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS}
    */
   categoricalColors?:
-    | ODSCHartsCategoricalColorsSet
-    | ODSCHartsCustomCategoricalColor[];
+    | ODSChartsCategoricalColorsSet
+    | ODSChartsCustomCategoricalColor[];
   /**
    * visualMapColor is the set of colours to be used if map graphs (like Heatmap)
    *
-   * Default visualMapColor is {@link ODSCHartsSequentialColorsSet.SEQUENTIAL_BLUE}
+   * Default visualMapColor is {@link ODSChartsSequentialColorsSet.SEQUENTIAL_BLUE}
    */
-  visualMapColor?: ODSCHartsSequentialColorsSet;
+  visualMapColor?: ODSChartsSequentialColorsSet;
   /**
    * lineStyle soecifies the style of line in lineCharts.
    *
@@ -177,10 +177,10 @@ const THEMES: {
     common: any;
     linesAxis: any;
     categoricalColors: {
-      [colorSet in ODSCHartsCategoricalColorsSet]: { color: string[] };
+      [colorSet in ODSChartsCategoricalColorsSet]: { color: string[] };
     };
     sequentialColors: {
-      [colorSet in ODSCHartsSequentialColorsSet]: { visualMapColor: string[] };
+      [colorSet in ODSChartsSequentialColorsSet]: { visualMapColor: string[] };
     };
     linesStyle: { [style in ODSChartsLineStyle]: any };
   };
@@ -300,10 +300,10 @@ export class ODSChartsTheme {
     const mode: ODSChartsMode = options.mode;
     if (!options.categoricalColors) {
       options.categoricalColors =
-        ODSCHartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS;
+        ODSChartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS;
     }
     if (!options.visualMapColor) {
-      options.visualMapColor = ODSCHartsSequentialColorsSet.SEQUENTIAL_BLUE;
+      options.visualMapColor = ODSChartsSequentialColorsSet.SEQUENTIAL_BLUE;
     }
     if (!options.lineStyle) {
       options.lineStyle = ODSChartsLineStyle.SMOOTH;

--- a/test/angular-ngx-echarts/src/app/graph/graph.component.ts
+++ b/test/angular-ngx-echarts/src/app/graph/graph.component.ts
@@ -48,8 +48,8 @@ export class GraphComponent {
   constructor() {
     this.myTheme = ODSCharts.getThemeManager({
       mode: ODSCharts.ODSChartsMode.LIGHT,
-      categoricalColors: ODSCharts.ODSCHartsCategoricalColorsSet.DARKER_TINTS,
-      visualMapColor: ODSCharts.ODSCHartsSequentialColorsSet.SEQUENTIAL_BLUE,
+      categoricalColors: ODSCharts.ODSChartsCategoricalColorsSet.DARKER_TINTS,
+      visualMapColor: ODSCharts.ODSChartsSequentialColorsSet.SEQUENTIAL_BLUE,
       lineStyle: ODSCharts.ODSChartsLineStyle.SMOOTH,
     });
   }

--- a/test/angular-tour-of-heroes/src/app/linechart.component.ts
+++ b/test/angular-tour-of-heroes/src/app/linechart.component.ts
@@ -85,8 +85,8 @@ export class LinechartComponent implements AfterViewInit {
     // ODS Charts
     const lineChartODSTheme = ODSCharts.getThemeManager({
       mode: ODSCharts.ODSChartsMode.DARK,
-      categoricalColors: ODSCharts.ODSCHartsCategoricalColorsSet.DARKER_TINTS,
-      visualMapColor: ODSCharts.ODSCHartsSequentialColorsSet.SEQUENTIAL_BLUE,
+      categoricalColors: ODSCharts.ODSChartsCategoricalColorsSet.DARKER_TINTS,
+      visualMapColor: ODSCharts.ODSChartsSequentialColorsSet.SEQUENTIAL_BLUE,
       lineStyle: ODSCharts.ODSChartsLineStyle.BROKEN_WITH_POINTS,
     });
 

--- a/test/examples/bar-line-chart/index.html
+++ b/test/examples/bar-line-chart/index.html
@@ -65,18 +65,18 @@
           categoricalColors: [
             {
               colorPalette:
-                ODSCharts.ODSCHartsCategoricalColorsSet
+                ODSCharts.ODSChartsCategoricalColorsSet
                   .DEFAULT_SUPPORTING_COLORS,
               colorIndex: 2,
             },
             {
               colorPalette:
-                ODSCharts.ODSCHartsCategoricalColorsSet.SEQUENTIAL_GREEN,
+                ODSCharts.ODSChartsCategoricalColorsSet.SEQUENTIAL_GREEN,
               colorIndex: 0,
             },
           ],
           visualMapColor:
-            ODSCharts.ODSCHartsSequentialColorsSet.SEQUENTIAL_BLUE,
+            ODSCharts.ODSChartsSequentialColorsSet.SEQUENTIAL_BLUE,
           lineStyle: ODSCharts.ODSChartsLineStyle.BROKEN_WITH_POINTS,
           cssTheme: ODSCharts.ODSChartsCSSThemes.NONE,
         });

--- a/test/examples/single-line-chart/index.html
+++ b/test/examples/single-line-chart/index.html
@@ -53,9 +53,9 @@
         var themeManager = ODSCharts.getThemeManager({
           mode: ODSCharts.ODSChartsMode.LIGHT,
           categoricalColors:
-            ODSCharts.ODSCHartsCategoricalColorsSet.SEQUENTIAL_PURPLE,
+            ODSCharts.ODSChartsCategoricalColorsSet.SEQUENTIAL_PURPLE,
           visualMapColor:
-            ODSCharts.ODSCHartsSequentialColorsSet.SEQUENTIAL_BLUE,
+            ODSCharts.ODSChartsSequentialColorsSet.SEQUENTIAL_BLUE,
           lineStyle: ODSCharts.ODSChartsLineStyle.SMOOTH,
           cssTheme: ODSCharts.ODSChartsCSSThemes.NONE,
         });

--- a/test/html/index.html
+++ b/test/html/index.html
@@ -18,8 +18,8 @@
       var lineChartODSTheme = ODSCharts.getThemeManager({
         mode: ODSCharts.ODSChartsMode.LIGHT,
         categoricalColors:
-          ODSCharts.ODSCHartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS,
-        visualMapColor: ODSCharts.ODSCHartsSequentialColorsSet.SEQUENTIAL_BLUE,
+          ODSCharts.ODSChartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS,
+        visualMapColor: ODSCharts.ODSChartsSequentialColorsSet.SEQUENTIAL_BLUE,
         lineStyle: ODSCharts.ODSChartsLineStyle.SMOOTH,
       });
       echarts.registerTheme(lineChartODSTheme.name, lineChartODSTheme.theme);

--- a/test/react/src/LineChartComponent.js
+++ b/test/react/src/LineChartComponent.js
@@ -55,8 +55,8 @@ class LineChartComponent extends Component {
     // ODS Charts
     const lineChartODSTheme = ODSCharts.getThemeManager({
       mode: ODSCharts.ODSChartsMode.DARK,
-      categoricalColors: ODSCharts.ODSCHartsCategoricalColorsSet.DARKER_TINTS,
-      visualMapColor: ODSCharts.ODSCHartsSequentialColorsSet.SEQUENTIAL_BLUE,
+      categoricalColors: ODSCharts.ODSChartsCategoricalColorsSet.DARKER_TINTS,
+      visualMapColor: ODSCharts.ODSChartsSequentialColorsSet.SEQUENTIAL_BLUE,
       lineStyle: ODSCharts.ODSChartsLineStyle.BROKEN_WITH_POINTS,
     });
 

--- a/test/vue/src/components/LineChartComponent.vue
+++ b/test/vue/src/components/LineChartComponent.vue
@@ -50,8 +50,8 @@ onMounted(() => {
   // ODS Charts
   const lineChartODSTheme = ODSCharts.getThemeManager({
     mode: ODSCharts.ODSChartsMode.DARK,
-    categoricalColors: ODSCharts.ODSCHartsCategoricalColorsSet.DARKER_TINTS,
-    visualMapColor: ODSCharts.ODSCHartsSequentialColorsSet.SEQUENTIAL_BLUE,
+    categoricalColors: ODSCharts.ODSChartsCategoricalColorsSet.DARKER_TINTS,
+    visualMapColor: ODSCharts.ODSChartsSequentialColorsSet.SEQUENTIAL_BLUE,
     lineStyle: ODSCharts.ODSChartsLineStyle.BROKEN_WITH_POINTS
   })
 


### PR DESCRIPTION
### Description

This PR simply fixes the following typo: 'ODSCHarts*' → 'ODSCharts*'.
It has an impact on the library's usage so we should release a new alpha.

During the review, please double-check that the examples are still working and that the API documentation is modified accordingly.

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Test checklist

Please check that the following tests projects are still working:

- [ ] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [ ] `test/angular-tour-of-heroes`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`

