### PR TITLE
fix(lib): Generate a module version of the library to be used as import in a devlopment source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0-alpha.13",
       "license": "MIT",
       "devDependencies": {
+        "@types/echarts": "^4.9.22",
         "echarts": "^5.5.1",
         "prettier": "^3.3.3",
         "serve": "^14.2.3",
@@ -137,6 +138,16 @@
       "integrity": "sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==",
       "dev": true
     },
+    "node_modules/@types/echarts": {
+      "version": "4.9.22",
+      "resolved": "https://registry.npmjs.org/@types/echarts/-/echarts-4.9.22.tgz",
+      "integrity": "sha512-7Fo6XdWpoi8jxkwP7BARUOM7riq8bMhmsCtSG8gzUcJmFhLo387tihoBYS/y5j7jl3PENT5RxeWZdN9RiwO7HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/zrender": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -201,6 +212,13 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true
+    },
+    "node_modules/@types/zrender": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/zrender/-/zrender-4.0.6.tgz",
+      "integrity": "sha512-1jZ9bJn2BsfmYFPBHtl5o3uV+ILejAtGrDcYSpT4qaVKEI/0YY+arw3XHU04Ebd8Nca3SQ7uNcLaqiL+tTFVMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "./dist/**/*"
   ],
   "main": "./dist/ods-charts.js",
+  "module": "./dist/ods-charts.esm.js",
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "webpack",
@@ -34,6 +35,7 @@
     "typedoc": "^0.26.11",
     "typescript": "^5.6.3",
     "webpack": "^5.96.1",
-    "webpack-cli": "^5.1.4"
+    "webpack-cli": "^5.1.4",
+    "@types/echarts": "^4.9.22"
   }
 }

--- a/test/angular-echarts/package-lock.json
+++ b/test/angular-echarts/package-lock.json
@@ -40,6 +40,7 @@
       "version": "0.1.0-alpha.13",
       "license": "MIT",
       "devDependencies": {
+        "@types/echarts": "^4.9.22",
         "echarts": "^5.5.1",
         "prettier": "^3.3.3",
         "serve": "^14.2.3",

--- a/test/angular-ngx-echarts/package-lock.json
+++ b/test/angular-ngx-echarts/package-lock.json
@@ -41,6 +41,7 @@
       "version": "0.1.0-alpha.13",
       "license": "MIT",
       "devDependencies": {
+        "@types/echarts": "^4.9.22",
         "echarts": "^5.5.1",
         "prettier": "^3.3.3",
         "serve": "^14.2.3",

--- a/test/react/package-lock.json
+++ b/test/react/package-lock.json
@@ -20,10 +20,10 @@
       }
     },
     "../..": {
-      "name": "ods-charts",
       "version": "0.1.0-alpha.13",
       "license": "MIT",
       "devDependencies": {
+        "@types/echarts": "^4.9.22",
         "echarts": "^5.5.1",
         "prettier": "^3.3.3",
         "serve": "^14.2.3",
@@ -16133,9 +16133,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -16143,7 +16143,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/test/vue/package-lock.json
+++ b/test/vue/package-lock.json
@@ -31,10 +31,10 @@
       }
     },
     "../..": {
-      "name": "ods-charts",
       "version": "0.1.0-alpha.13",
       "license": "MIT",
       "devDependencies": {
+        "@types/echarts": "^4.9.22",
         "echarts": "^5.5.1",
         "prettier": "^3.3.3",
         "serve": "^14.2.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs" /* Specify what module code is generated. */,
+    "module": "ESNext" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
@@ -40,7 +40,7 @@
     // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
     // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
     // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
-    "resolveJsonModule": true /* Enable importing .json files. */,
+    // "resolveJsonModule": true /* Enable importing .json files. */,
     // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,16 +1,10 @@
 const path = require('path');
 
-module.exports = {
+const defaultConfig = {
   mode: 'development',
   devtool: 'inline-source-map',
   entry: {
     main: './index.ts',
-  },
-  output: {
-    path: path.resolve(__dirname, './dist'),
-    filename: 'ods-charts.js',
-    libraryTarget: 'umd',
-    library: 'ODSCharts',
   },
   resolve: {
     extensions: ['.ts', '.tsx', '.js'],
@@ -24,3 +18,30 @@ module.exports = {
     ],
   },
 };
+
+module.exports = [
+  {
+    ...defaultConfig,
+    output: {
+      path: path.resolve(__dirname, './dist'),
+      filename: 'ods-charts.js',
+      library: {
+        type: 'umd',
+        name: 'ODSCharts',
+      },
+    },
+  },
+  {
+    ...defaultConfig,
+    output: {
+      path: path.resolve(__dirname, './dist'),
+      filename: 'ods-charts.esm.js',
+      library: {
+        type: 'module',
+      },
+    },
+    experiments: {
+      outputModule: true,
+    },
+  },
+];


### PR DESCRIPTION
### Related issues

https://github.com/Orange-OpenSource/ods-charts/issues/18

### Description

Angular compilation gave a warning on CommonJS or AMD dependencies

To get code generation optimized, it is recommended that you use [ECMAScript modules](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/import).

The Pull request contains:
- the library is compiled as a module ESNext and declared as a module
- webpack generates two bundle : 
  - ods-chart.js is still used in HTML <script> 
  - ods-charts-module.js is the one referenced in package.json to be used as the imported module
-  some vue and react compilation problems


### Motivation & Context

Code optimization

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)
- Refactoring (non-breaking change)

### Test checklist

Please check that the following tests projects are still working:

- [x] `docs/examples`
- [x] `test/angular-ngx-echarts`
- [x] `test/angular-tour-of-heroes`
- [x] `test/html`
- [ ] `test/react`
- [x] `test/vue`
- [x] `test/examples/bar-line-chart`
- [x] `test/examples/single-line-chart`

