### PR TITLE
chore(deps-dev): bump echarts from 5.4.3 to 5.5.0 in the lib and test…

### DIFF
--- a/docs/examples/bar-chart.html
+++ b/docs/examples/bar-chart.html
@@ -22,7 +22,7 @@
        Echarts 
       -------------------------------------------------->
     <script src="
-    https://cdn.jsdelivr.net/npm/echarts@5.4.2/dist/echarts.min.js
+    https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js
     "></script>
     <script type="text/javascript" src="../../dist/ods-charts.js"></script>
     <script type="module" src="./index.js"></script>

--- a/docs/examples/bar-line-chart.html
+++ b/docs/examples/bar-line-chart.html
@@ -22,7 +22,7 @@
        Echarts 
       -------------------------------------------------->
     <script src="
-    https://cdn.jsdelivr.net/npm/echarts@5.4.2/dist/echarts.min.js
+    https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js
     "></script>
     <script type="text/javascript" src="../../dist/ods-charts.js"></script>
     <script type="module" src="./index.js"></script>

--- a/docs/examples/multiple-line-chart.html
+++ b/docs/examples/multiple-line-chart.html
@@ -22,7 +22,7 @@
        Echarts 
       -------------------------------------------------->
     <script src="
-    https://cdn.jsdelivr.net/npm/echarts@5.4.2/dist/echarts.min.js
+    https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js
     "></script>
     <script type="text/javascript" src="../../dist/ods-charts.js"></script>
     <script type="module" src="./index.js"></script>

--- a/docs/examples/single-line-chart.html
+++ b/docs/examples/single-line-chart.html
@@ -22,7 +22,7 @@
        Echarts 
       -------------------------------------------------->
     <script src="
-    https://cdn.jsdelivr.net/npm/echarts@5.4.2/dist/echarts.min.js
+    https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js
     "></script>
     <script type="text/javascript" src="../../dist/ods-charts.js"></script>
     <script type="module" src="./index.js"></script>

--- a/docs/examples/stacked-bar-chart.html
+++ b/docs/examples/stacked-bar-chart.html
@@ -22,7 +22,7 @@
        Echarts 
       -------------------------------------------------->
     <script src="
-    https://cdn.jsdelivr.net/npm/echarts@5.4.2/dist/echarts.min.js
+    https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js
     "></script>
     <script type="text/javascript" src="../../dist/ods-charts.js"></script>
     <script type="module" src="./index.js"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0-alpha.4",
       "license": "MIT",
       "devDependencies": {
-        "echarts": "^5.4.3",
+        "echarts": "^5.5.0",
         "serve": "^14.2.1",
         "ts-loader": "^9.5.1",
         "typedoc": "^0.25.8",
@@ -846,13 +846,13 @@
       "dev": true
     },
     "node_modules/echarts": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.4.3.tgz",
-      "integrity": "sha512-mYKxLxhzy6zyTi/FaEbJMOZU1ULGEQHaeIeuMR5L+JnJTpz+YR03mnnpBhbR4+UYJAgiXgpyTVLffPAjOTLkZA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.0.tgz",
+      "integrity": "sha512-rNYnNCzqDAPCr4m/fqyUFv7fD9qIsd50S6GDFgO1DxZhncCsNsG7IfUlAlvZe5oSEQxtsjnHiUuppzccry93Xw==",
       "dev": true,
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.4.4"
+        "zrender": "5.5.0"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2474,9 +2474,9 @@
       "dev": true
     },
     "node_modules/zrender": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.4.4.tgz",
-      "integrity": "sha512-0VxCNJ7AGOMCWeHVyTrGzUgrK4asT4ml9PEkeGirAkKNYXYzoPJCLvmyfdoOXcjTHPs10OZVMfD1Rwg16AZyYw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.5.0.tgz",
+      "integrity": "sha512-O3MilSi/9mwoovx77m6ROZM7sXShR/O/JIanvzTwjN3FORfLSr81PsUGd7jlaYOeds9d8tw82oP44+3YucVo+w==",
       "dev": true,
       "dependencies": {
         "tslib": "2.3.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "typedoc": "typedoc --out docs/api src/ods-charts.ts --disableSources --excludePrivate --excludeProtected  --readme docs/README.md"
   },
   "devDependencies": {
-    "echarts": "^5.4.3",
+    "echarts": "^5.5.0",
     "serve": "^14.2.1",
     "ts-loader": "^9.5.1",
     "typedoc": "^0.25.8",

--- a/src/theme/popover/ods-chart-popover.ts
+++ b/src/theme/popover/ods-chart-popover.ts
@@ -320,7 +320,7 @@ export class ODSChartsPopover {
     if (this.popoverConfig.enabled) {
       mergeObjects(popoverOptions, {
         tooltip: {
-          appendToBody: true,
+          appendTo: 'body',
           enterable: true,
         },
         [tooltipTrigger]: {
@@ -371,7 +371,7 @@ export class ODSChartsPopover {
             },
             showDelay: 0,
             hideDelay: 0,
-            appendToBody: true,
+            appendTo: 'body',
             renderMode: 'html',
             className: `ods-charts-popover ods-charts-mode-${mode} ${ODSChartsItemCSSDefinition.getClasses(
               cssTheme.popover?.odsChartsPopover
@@ -424,7 +424,7 @@ export class ODSChartsPopover {
               }
               return ' ';
             },
-            appendToBody: true,
+            appendTo: 'body',
             className: 'd-none',
             axisPointer: {
               type: this.popoverConfig.axisPointer,

--- a/test/angular-echarts/package-lock.json
+++ b/test/angular-echarts/package-lock.json
@@ -16,7 +16,7 @@
         "@angular/platform-browser": "^17.2.1",
         "@angular/platform-browser-dynamic": "^17.2.1",
         "@angular/router": "^17.2.1",
-        "echarts": "^5.4.3",
+        "echarts": "^5.5.0",
         "ods-charts": "file:../..",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -40,12 +40,12 @@
       "version": "0.1.0-alpha.4",
       "license": "MIT",
       "devDependencies": {
-        "echarts": "^5.4.3",
+        "echarts": "^5.5.0",
         "serve": "^14.2.1",
         "ts-loader": "^9.5.1",
         "typedoc": "^0.25.8",
         "typescript": "^5.3.3",
-        "webpack": "^5.90.1",
+        "webpack": "^5.90.3",
         "webpack-cli": "^5.1.4"
       }
     },
@@ -5477,12 +5477,12 @@
       "dev": true
     },
     "node_modules/echarts": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.4.3.tgz",
-      "integrity": "sha512-mYKxLxhzy6zyTi/FaEbJMOZU1ULGEQHaeIeuMR5L+JnJTpz+YR03mnnpBhbR4+UYJAgiXgpyTVLffPAjOTLkZA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.0.tgz",
+      "integrity": "sha512-rNYnNCzqDAPCr4m/fqyUFv7fD9qIsd50S6GDFgO1DxZhncCsNsG7IfUlAlvZe5oSEQxtsjnHiUuppzccry93Xw==",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.4.4"
+        "zrender": "5.5.0"
       }
     },
     "node_modules/echarts/node_modules/tslib": {
@@ -12456,9 +12456,9 @@
       }
     },
     "node_modules/zrender": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.4.4.tgz",
-      "integrity": "sha512-0VxCNJ7AGOMCWeHVyTrGzUgrK4asT4ml9PEkeGirAkKNYXYzoPJCLvmyfdoOXcjTHPs10OZVMfD1Rwg16AZyYw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.5.0.tgz",
+      "integrity": "sha512-O3MilSi/9mwoovx77m6ROZM7sXShR/O/JIanvzTwjN3FORfLSr81PsUGd7jlaYOeds9d8tw82oP44+3YucVo+w==",
       "dependencies": {
         "tslib": "2.3.0"
       }

--- a/test/angular-echarts/package.json
+++ b/test/angular-echarts/package.json
@@ -18,7 +18,7 @@
     "@angular/platform-browser": "^17.2.1",
     "@angular/platform-browser-dynamic": "^17.2.1",
     "@angular/router": "^17.2.1",
-    "echarts": "^5.4.3",
+    "echarts": "^5.5.0",
     "ods-charts": "file:../..",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/test/angular-ngx-echarts/package-lock.json
+++ b/test/angular-ngx-echarts/package-lock.json
@@ -16,7 +16,7 @@
         "@angular/platform-browser": "^17.2.1",
         "@angular/platform-browser-dynamic": "^17.2.1",
         "@angular/router": "^17.2.1",
-        "echarts": "^5.4.3",
+        "echarts": "^5.5.0",
         "ngx-echarts": "^17.1.0",
         "ods-charts": "file:../..",
         "rxjs": "~7.8.0",
@@ -41,12 +41,12 @@
       "version": "0.1.0-alpha.4",
       "license": "MIT",
       "devDependencies": {
-        "echarts": "^5.4.3",
+        "echarts": "^5.5.0",
         "serve": "^14.2.1",
         "ts-loader": "^9.5.1",
         "typedoc": "^0.25.8",
         "typescript": "^5.3.3",
-        "webpack": "^5.90.1",
+        "webpack": "^5.90.3",
         "webpack-cli": "^5.1.4"
       }
     },
@@ -5478,12 +5478,12 @@
       "dev": true
     },
     "node_modules/echarts": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.4.3.tgz",
-      "integrity": "sha512-mYKxLxhzy6zyTi/FaEbJMOZU1ULGEQHaeIeuMR5L+JnJTpz+YR03mnnpBhbR4+UYJAgiXgpyTVLffPAjOTLkZA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.0.tgz",
+      "integrity": "sha512-rNYnNCzqDAPCr4m/fqyUFv7fD9qIsd50S6GDFgO1DxZhncCsNsG7IfUlAlvZe5oSEQxtsjnHiUuppzccry93Xw==",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.4.4"
+        "zrender": "5.5.0"
       }
     },
     "node_modules/echarts/node_modules/tslib": {
@@ -12468,9 +12468,9 @@
       }
     },
     "node_modules/zrender": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.4.4.tgz",
-      "integrity": "sha512-0VxCNJ7AGOMCWeHVyTrGzUgrK4asT4ml9PEkeGirAkKNYXYzoPJCLvmyfdoOXcjTHPs10OZVMfD1Rwg16AZyYw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.5.0.tgz",
+      "integrity": "sha512-O3MilSi/9mwoovx77m6ROZM7sXShR/O/JIanvzTwjN3FORfLSr81PsUGd7jlaYOeds9d8tw82oP44+3YucVo+w==",
       "dependencies": {
         "tslib": "2.3.0"
       }

--- a/test/angular-ngx-echarts/package.json
+++ b/test/angular-ngx-echarts/package.json
@@ -18,7 +18,7 @@
     "@angular/platform-browser": "^17.2.1",
     "@angular/platform-browser-dynamic": "^17.2.1",
     "@angular/router": "^17.2.1",
-    "echarts": "^5.4.3",
+    "echarts": "^5.5.0",
     "ngx-echarts": "^17.1.0",
     "ods-charts": "file:../..",
     "rxjs": "~7.8.0",

--- a/test/react/package-lock.json
+++ b/test/react/package-lock.json
@@ -11,7 +11,7 @@
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^14.2.1",
         "@testing-library/user-event": "^14.5.2",
-        "echarts": "^5.4.3",
+        "echarts": "^5.5.0",
         "ods-charts": "file:../..",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -20,16 +20,15 @@
       }
     },
     "../..": {
-      "name": "ods-charts",
       "version": "0.1.0-alpha.4",
       "license": "MIT",
       "devDependencies": {
-        "echarts": "^5.4.3",
+        "echarts": "^5.5.0",
         "serve": "^14.2.1",
         "ts-loader": "^9.5.1",
-        "typedoc": "^0.25.7",
+        "typedoc": "^0.25.8",
         "typescript": "^5.3.3",
-        "webpack": "^5.90.0",
+        "webpack": "^5.90.3",
         "webpack-cli": "^5.1.4"
       }
     },
@@ -8044,12 +8043,12 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
     },
     "node_modules/echarts": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.4.3.tgz",
-      "integrity": "sha512-mYKxLxhzy6zyTi/FaEbJMOZU1ULGEQHaeIeuMR5L+JnJTpz+YR03mnnpBhbR4+UYJAgiXgpyTVLffPAjOTLkZA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.0.tgz",
+      "integrity": "sha512-rNYnNCzqDAPCr4m/fqyUFv7fD9qIsd50S6GDFgO1DxZhncCsNsG7IfUlAlvZe5oSEQxtsjnHiUuppzccry93Xw==",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.4.4"
+        "zrender": "5.5.0"
       }
     },
     "node_modules/echarts/node_modules/tslib": {
@@ -22392,9 +22391,9 @@
       }
     },
     "node_modules/zrender": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.4.4.tgz",
-      "integrity": "sha512-0VxCNJ7AGOMCWeHVyTrGzUgrK4asT4ml9PEkeGirAkKNYXYzoPJCLvmyfdoOXcjTHPs10OZVMfD1Rwg16AZyYw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.5.0.tgz",
+      "integrity": "sha512-O3MilSi/9mwoovx77m6ROZM7sXShR/O/JIanvzTwjN3FORfLSr81PsUGd7jlaYOeds9d8tw82oP44+3YucVo+w==",
       "dependencies": {
         "tslib": "2.3.0"
       }

--- a/test/react/package.json
+++ b/test/react/package.json
@@ -6,7 +6,7 @@
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.2.1",
     "@testing-library/user-event": "^14.5.2",
-    "echarts": "^5.4.3",
+    "echarts": "^5.5.0",
     "ods-charts": "file:../..",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/test/vue/package-lock.json
+++ b/test/vue/package-lock.json
@@ -8,7 +8,7 @@
       "name": "vue",
       "version": "0.0.0",
       "dependencies": {
-        "echarts": "^5.4.3",
+        "echarts": "^5.5.0",
         "ods-charts": "file:../..",
         "vue": "^3.3.4"
       },
@@ -31,16 +31,15 @@
       }
     },
     "../..": {
-      "name": "ods-charts",
       "version": "0.1.0-alpha.4",
       "license": "MIT",
       "devDependencies": {
-        "echarts": "^5.4.3",
+        "echarts": "^5.5.0",
         "serve": "^14.2.1",
         "ts-loader": "^9.5.1",
         "typedoc": "^0.25.8",
         "typescript": "^5.3.3",
-        "webpack": "^5.90.1",
+        "webpack": "^5.90.3",
         "webpack-cli": "^5.1.4"
       }
     },
@@ -2225,12 +2224,12 @@
       }
     },
     "node_modules/echarts": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.4.3.tgz",
-      "integrity": "sha512-mYKxLxhzy6zyTi/FaEbJMOZU1ULGEQHaeIeuMR5L+JnJTpz+YR03mnnpBhbR4+UYJAgiXgpyTVLffPAjOTLkZA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.0.tgz",
+      "integrity": "sha512-rNYnNCzqDAPCr4m/fqyUFv7fD9qIsd50S6GDFgO1DxZhncCsNsG7IfUlAlvZe5oSEQxtsjnHiUuppzccry93Xw==",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.4.4"
+        "zrender": "5.5.0"
       }
     },
     "node_modules/echarts/node_modules/tslib": {
@@ -4447,9 +4446,9 @@
       }
     },
     "node_modules/zrender": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.4.4.tgz",
-      "integrity": "sha512-0VxCNJ7AGOMCWeHVyTrGzUgrK4asT4ml9PEkeGirAkKNYXYzoPJCLvmyfdoOXcjTHPs10OZVMfD1Rwg16AZyYw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.5.0.tgz",
+      "integrity": "sha512-O3MilSi/9mwoovx77m6ROZM7sXShR/O/JIanvzTwjN3FORfLSr81PsUGd7jlaYOeds9d8tw82oP44+3YucVo+w==",
       "dependencies": {
         "tslib": "2.3.0"
       }

--- a/test/vue/package.json
+++ b/test/vue/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
-    "echarts": "^5.4.3",
+    "echarts": "^5.5.0",
     "ods-charts": "file:../..",
     "vue": "^3.3.4"
   },


### PR DESCRIPTION
### Description

This PR supersedes https://github.com/Orange-OpenSource/ods-charts/pull/140 which is not complete.

This PR bumps echarts version from 5.4.3 to 5.5.0 for the ODS Charts library, but also for all test projects (in their `package.json` or CDN versions).

As mentioned by @louismaximepiton in https://github.com/Orange-OpenSource/ods-charts/pull/140#issuecomment-1956127266, `appendToBody` is now deprecated, so this PR now uses `appendTo: 'body'` instead. This is not that important right now as our library is in alpha. But in the future, we need to think about it precisely as our library would be compatible only from v5.5.0.

Please note that their change to ESM default package doesn't seem to impact us.