### PR TITLE
Remove `tooltipConfine` option

### DIFF
--- a/src/theme/popover/ods-chart-popover-definitions.ts
+++ b/src/theme/popover/ods-chart-popover-definitions.ts
@@ -98,19 +98,6 @@ export class ODSChartsPopoverConfig {
    */
   tooltip?: boolean;
   /**
-   * @experimental
-   * Whether confine popover content in the view rect of chart instance by rendering the arrow close to the mouse position.
-   *
-   * - true: to display tooltip inside the chart at any cost
-   * - false: to display tooltip normally
-   *
-   * @remarks
-   * Right now, this experimental option is not linked to the default behavior of Apache ECharts `tooltip.confine` option.
-   *
-   * So `tooltipConfine` can't be used at the same time as Apache ECharts `tooltip.confine` option. They are mutually exclusive.
-   */
-  tooltipConfine?: boolean;
-  /**
    * tooltipTimeout is used to set the timeout in milliseconds of the tooltip display.
    *
    * default value is 3000

--- a/src/theme/popover/ods-chart-popover.ts
+++ b/src/theme/popover/ods-chart-popover.ts
@@ -139,9 +139,6 @@ export class ODSChartsPopover {
     if (undefined === popoverConfig.tooltip) {
       popoverConfig.tooltip = true;
     }
-    if (undefined === popoverConfig.tooltipConfine) {
-      popoverConfig.tooltipConfine = false;
-    }
     if (undefined === popoverConfig.tooltipDelay) {
       popoverConfig.tooltipDelay =
         undefined === popoverDefinition.tooltipDelay
@@ -317,7 +314,6 @@ export class ODSChartsPopover {
         tooltip: {
           appendTo: 'body',
           enterable: true,
-          confine: this.popoverConfig.tooltipConfine,
         },
         [tooltipTrigger]: {
           axisPointer: {
@@ -345,7 +341,7 @@ export class ODSChartsPopover {
                 left: pos[0] - size.contentSize[0] / 2,
               };
 
-              if (this.popoverConfig.tooltipConfine) {
+              if (dataOptions?.tooltip?.confine) {
                 const x = pos[0];
                 const arrowSize = 10;
                 const bottom = pos[1] > size.contentSize[1];

--- a/test/examples/bar-line-chart/index.html
+++ b/test/examples/bar-line-chart/index.html
@@ -34,9 +34,6 @@
 
         // this is the data to be displayed
         var dataOptions = {
-          grid: {
-            right: '1%'
-          },
           xAxis: {
             type: 'category',
             data: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
@@ -57,9 +54,6 @@
           legend: {
             data: ['label 0', 'label 1'],
           },
-          tooltip: {
-            confine: true,
-          }
         };
 
         ///////////////////////////////////////////////////

--- a/test/examples/bar-line-chart/index.html
+++ b/test/examples/bar-line-chart/index.html
@@ -34,6 +34,9 @@
 
         // this is the data to be displayed
         var dataOptions = {
+          grid: {
+            right: '1%'
+          },
           xAxis: {
             type: 'category',
             data: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
@@ -54,6 +57,9 @@
           legend: {
             data: ['label 0', 'label 1'],
           },
+          tooltip: {
+            confine: true,
+          }
         };
 
         ///////////////////////////////////////////////////


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Closes #146.

### Description

Remove useless `tooltipConfine`.

### Motivation & Context

There was an issue using this new option in #107 and there is no need for it anymore after the patch.
Sorry for the issue.

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (breaking which fixes an issue)