### PR TITLE
Docs: isolate charts in `<iframe>`s

### DIFF
--- a/docs/examples/bar-chart.html
+++ b/docs/examples/bar-chart.html
@@ -6,6 +6,7 @@
     <title>Bar Charts - Examples - ODS Charts</title>
     <link href="https://cdn.jsdelivr.net" rel="preconnect" crossorigin="anonymous" />
     <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/orange-helvetica.min.css" rel="stylesheet" integrity="sha384-A0Qk1uKfS1i83/YuU13i2nx5pk79PkIfNFOVzTcjCMPGKIDj9Lqx9lJmV7cdBVQZ" crossorigin="anonymous" />
+    <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/boosted.min.css" rel="stylesheet" integrity="sha384-laZ3JUZ5Ln2YqhfBvadDpNyBo7w5qmWaRnnXuRwNhJeTEFuSdGbzl4ZGHAEnTozR" crossorigin="anonymous" />
     <link href="../assets/tarteaucitron-config.css" rel="stylesheet" />
     <link rel="apple-touch-icon" href="../images/favicons/apple-touch-icon.png" sizes="180x180" />
     <link rel="icon" href="../images/favicons/favicon-32x32.png" sizes="32x32" type="image/png" />
@@ -16,12 +17,7 @@
     <meta name="msapplication-config" content="../images/favicons/browserconfig.xml" />
     <meta name="theme-color" content="#000" />
 
-    <!--------------------------------------------------
-       Echarts 
-      -------------------------------------------------->
-    <script src="
-    https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js
-    "></script>
+    <!-- Here for access to maps, no logic behind -->
     <script type="text/javascript" src="../../dist/ods-charts.js"></script>
     <script type="module" src="./index.js"></script>
   </head>
@@ -113,6 +109,7 @@
         </div>
       </div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/js/boosted.bundle.min.js" integrity="sha384-3RoJImQ+Yz4jAyP6xW29kJhqJOE3rdjuu9wkNycjCuDnGAtC/crm79mLcwj1w2o/" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/tarteaucitronjs@1.17.0/tarteaucitron.min.js" integrity="sha384-g6Xxn1zA15svldHyZ/Ow+wUUeRxHf/v7eOOO2sMafcnMPFD25n80Yz/3bbhJBSoN" crossorigin="anonymous"></script>
     <script src="../assets/tarteaucitron-config.js"></script>
   </body>

--- a/docs/examples/bar-chart.html
+++ b/docs/examples/bar-chart.html
@@ -16,7 +16,9 @@
     <link rel="icon" href="../images/favicons/favicon.ico" />
     <meta name="msapplication-config" content="../images/favicons/browserconfig.xml" />
     <meta name="theme-color" content="#000" />
-    <!-- Here for access to maps, no logic behind -->
+    <!--
+      `ods-charts.js` is already imported by the iframe. However, it is imported here too to access the enums that are used in `index.js`.
+    -->
     <script type="text/javascript" src="../../dist/ods-charts.js"></script>
     <script type="module" src="./index.js"></script>
   </head>

--- a/docs/examples/bar-line-chart.html
+++ b/docs/examples/bar-line-chart.html
@@ -16,7 +16,9 @@
     <link rel="icon" href="../images/favicons/favicon.ico" />
     <meta name="msapplication-config" content="../images/favicons/browserconfig.xml" />
     <meta name="theme-color" content="#000" />
-    <!-- Here for access to maps, no logic behind -->
+    <!--
+      `ods-charts.js` is already imported by the iframe. However, it is imported here too to access the enums that are used in `index.js`.
+    -->
     <script type="text/javascript" src="../../dist/ods-charts.js"></script>
     <script type="module" src="./index.js"></script>
   </head>

--- a/docs/examples/bar-line-chart.html
+++ b/docs/examples/bar-line-chart.html
@@ -6,6 +6,7 @@
     <title>Bar + line Charts - Examples - ODS Charts</title>
     <link href="https://cdn.jsdelivr.net" rel="preconnect" crossorigin="anonymous" />
     <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/orange-helvetica.min.css" rel="stylesheet" integrity="sha384-A0Qk1uKfS1i83/YuU13i2nx5pk79PkIfNFOVzTcjCMPGKIDj9Lqx9lJmV7cdBVQZ" crossorigin="anonymous" />
+    <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/boosted.min.css" rel="stylesheet" integrity="sha384-laZ3JUZ5Ln2YqhfBvadDpNyBo7w5qmWaRnnXuRwNhJeTEFuSdGbzl4ZGHAEnTozR" crossorigin="anonymous" />
     <link href="../assets/tarteaucitron-config.css" rel="stylesheet" />
     <link rel="apple-touch-icon" href="../images/favicons/apple-touch-icon.png" sizes="180x180" />
     <link rel="icon" href="../images/favicons/favicon-32x32.png" sizes="32x32" type="image/png" />
@@ -16,12 +17,7 @@
     <meta name="msapplication-config" content="../images/favicons/browserconfig.xml" />
     <meta name="theme-color" content="#000" />
 
-    <!--------------------------------------------------
-       Echarts 
-      -------------------------------------------------->
-    <script src="
-    https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js
-    "></script>
+    <!-- Here for access to maps, no logic behind -->
     <script type="text/javascript" src="../../dist/ods-charts.js"></script>
     <script type="module" src="./index.js"></script>
   </head>
@@ -71,6 +67,7 @@
         </div>
       </div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/js/boosted.bundle.min.js" integrity="sha384-3RoJImQ+Yz4jAyP6xW29kJhqJOE3rdjuu9wkNycjCuDnGAtC/crm79mLcwj1w2o/" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/tarteaucitronjs@1.17.0/tarteaucitron.min.js" integrity="sha384-g6Xxn1zA15svldHyZ/Ow+wUUeRxHf/v7eOOO2sMafcnMPFD25n80Yz/3bbhJBSoN" crossorigin="anonymous"></script>
     <script src="../assets/tarteaucitron-config.js"></script>
   </body>

--- a/docs/examples/index.js
+++ b/docs/examples/index.js
@@ -219,7 +219,7 @@ function generateExampleDiv(id) {
 <link id="mainCSS" cssThemeName="BOOSTED5" href="${themeElements.BOOSTED5.css[1]}" rel="stylesheet">
 <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js" integrity="sha384-o5uz97et3bErHvpKfD4Jz4n0JfhJDWABFuF4NP+iEEDxE1VwMWJ19QGR0lqFZnr6" crossorigin="anonymous"></script>
 <script type="text/javascript" src="../../dist/ods-charts.js"></script>
-<script type="text/javascript" src="./index.js"></script>
+<script type="module" src="./index.js"></script>
 <script id="mainJS" src="${themeElements.BOOSTED5.script[0]}"></script>
 ${generateChartDiv(id)}`);
   iframeDocument.close();

--- a/docs/examples/index.js
+++ b/docs/examples/index.js
@@ -1,19 +1,22 @@
 import 'https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js';
 
+const BOOSTED4_VERSION = '4.6.2';
+const BOOSTED5_VERSION = '5.3.3';
+
 var themeElements = {
   BOOSTED5: {
     css: [
-      'https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/orange-helvetica.min.css',
-      'https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/boosted.min.css',
+      `https://cdn.jsdelivr.net/npm/boosted@${BOOSTED5_VERSION}/dist/css/orange-helvetica.min.css`,
+      `https://cdn.jsdelivr.net/npm/boosted@${BOOSTED5_VERSION}/dist/css/boosted.min.css`,
     ],
-    script: ['https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js', 'https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/js/boosted.min.js'],
+    script: [`https://cdn.jsdelivr.net/npm/boosted@${BOOSTED5_VERSION}/dist/js/boosted.bundle.min.js`],
   },
   BOOSTED4: {
     css: [
-      'https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/orange-helvetica.min.css',
-      'https://cdn.jsdelivr.net/npm/boosted@4.6.2/dist/css/boosted.min.css',
+      `https://cdn.jsdelivr.net/npm/boosted@${BOOSTED4_VERSION}/dist/css/orangeHelvetica.min.css`,
+      `https://cdn.jsdelivr.net/npm/boosted@${BOOSTED4_VERSION}/dist/css/boosted.min.css`,
     ],
-    script: ['https://code.jquery.com/jquery-3.5.1.slim.min.js', 'https://cdn.jsdelivr.net/npm/boosted@4.6.2/dist/js/boosted.bundle.min.js'],
+    script: [`https://cdn.jsdelivr.net/npm/boosted@${BOOSTED4_VERSION}/dist/js/boosted.bundle.min.js`, `https://code.jquery.com/jquery-3.5.1.slim.min.js`],
   },
   NONE: {
     css: [],
@@ -21,8 +24,9 @@ var themeElements = {
   },
 };
 
+// Generate examples
 function buildChartDiv(id) {
-  return `<div id="${id}_chart" style="width:100%; height:50vh"  class=" position-relative "></div>`;
+  return `<div id="${id}_chart" style="width:100%; height:100%; position: relative;"></div>`;
 }
 
 async function wait(timer = 0) {
@@ -35,106 +39,64 @@ async function wait(timer = 0) {
 
 function generateChartDiv(id) {
   return `
-  <div class="border border-light position-relative">
+  <div class="border border-light" style="display: flex; flex-direction: column; height: 100%;">
     <div class="chart_title">
-        <h4 class="display-4 mx-3 mb-1 mt-3">Title</h4>
-        <h5 class="display-5 mx-3 mb-1 mt-0">Sub-Title</h5>
+      <h4 class="display-4 mx-3 mb-1 mt-3">Title</h4>
+      <h5 class="display-5 mx-3 mb-1 mt-0">Sub-Title</h5>
     </div>
-    <div id="${id}_holder">
-        ${buildChartDiv(id)}
+    <div id="${id}_holder" style="flex-grow: 1; flex-shrink: 1;">
+      ${buildChartDiv(id)}
     </div>
-    <div  id="${id}_legend">
-    </div>
+    <div id="${id}_legend"></div>
   </div>`;
 }
 
-function generateConfigurator(id, cssThemeName) {
+function generateConfigurator(id) {
   const accordionThemes = {
-    [ODSCharts.ODSChartsCSSThemesNames.BOOSTED5]: {
-      accordion: {
-        begin: (id) => `<div class="accordion" id="${id}">`,
-        end: (id) => `</div>`,
-      },
-      item: {
-        begin: (id, itemId) => `<div class="accordion-item">`,
-        end: (id, itemId) => `</div>`,
-      },
-      header: {
-        begin: (id, itemId) => `<h2 class="accordion-header" id="${itemId}">
-      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" 
-      data-bs-target="#collapse_${itemId}" aria-expanded="false" aria-controls="collapse_${itemId}">
-`,
-        end: (id, itemId) => `</button>
+    accordion: {
+      begin: (id) => `<div class="accordion" id="${id}">`,
+      end: (id) => `</div>`,
+    },
+    item: {
+      begin: (id, itemId) => `<div class="accordion-item">`,
+      end: (id, itemId) => `</div>`,
+    },
+    header: {
+      begin: (id, itemId) => `<h2 class="accordion-header" id="${itemId}">
+    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" 
+    data-bs-target="#collapse_${itemId}" aria-expanded="false" aria-controls="collapse_${itemId}">`,
+      end: (id, itemId) => `</button>
 </h2>`,
-      },
-      content: {
-        begin: (id, itemId) => `<div id="collapse_${itemId}" class="accordion-collapse collapse" 
-      aria-labelledby="${itemId}" data-bs-parent="#${id}">
-      <div class="accordion-body" id="body_${itemId}">`,
-        end: (id, itemId) => ` </div>
-      </div>`,
-      },
     },
-    [ODSCharts.ODSChartsCSSThemesNames.BOOSTED4]: {
-      accordion: {
-        begin: (id) => `<div id="${id}" role="tablist" class="accordion">`,
-        end: (id) => `</div>`,
-      },
-      item: {
-        begin: (id, itemId) => `<div class="card">`,
-        end: (id, itemId) => `</div>`,
-      },
-      header: {
-        begin: (id, itemId) => `<div class="card-header" role="tab" id="${itemId}">
-      <h5 class="mb-0">
-        <a class="collapsed" data-toggle="collapse" href="#collapse_${itemId}" role="button" 
-        aria-expanded="false" aria-controls="collapse_${itemId}">
-`,
-        end: (id, itemId) => `</a>
-        </h5>
-      </div>`,
-      },
-      content: {
-        begin: (id, itemId) => `<div id="collapse_${itemId}" class="collapse" role="tabpanel" data-parent="#${id}" aria-labelledby="${itemId}">
-      <div class="card-body" id="body_${itemId}">`,
-        end: (id, itemId) => `</div>
-        </div>`,
-      },
-    },
-    [ODSCharts.ODSChartsCSSThemesNames.NONE]: {
-      accordion: { begin: (id) => `<div id="${id}">`, end: (id) => `</div>` },
-      item: { begin: (id, itemId) => `<div>`, end: (id, itemId) => `</div>` },
-      header: {
-        begin: (id, itemId) => `<div id="${itemId}"><h5>`,
-        end: (id, itemId) => `</h5></div>`,
-      },
-      content: {
-        begin: (id, itemId) => `<div id="collapse_${itemId}"> <div id="body_${itemId}">`,
-        end: (id, itemId) => `</div></div>`,
-      },
+    content: {
+      begin: (id, itemId) => `<div id="collapse_${itemId}" class="accordion-collapse collapse" 
+    aria-labelledby="${itemId}" data-bs-parent="#${id}">
+    <div class="accordion-body" id="body_${itemId}">`,
+      end: (id, itemId) => `</div>
+    </div>`,
     },
   };
   return `
-  ${accordionThemes[cssThemeName].accordion.begin('accordion_' + id)}
-    ${accordionThemes[cssThemeName].item.begin('accordion_' + id, 'content_1_' + id)}
-      ${accordionThemes[cssThemeName].header.begin('accordion_' + id, 'content_1_' + id)}
+  ${accordionThemes.accordion.begin('accordion_' + id)}
+    ${accordionThemes.item.begin('accordion_' + id, 'content_1_' + id)}
+      ${accordionThemes.header.begin('accordion_' + id, 'content_1_' + id)}
         Theme configuration
-      ${accordionThemes[cssThemeName].header.end('accordion_' + id, 'content_1_' + id)}
-      ${accordionThemes[cssThemeName].content.begin('accordion_' + id, 'content_1_' + id)}
-        <div class="one-chart-configurator" data-chart-id="${id}">                
+      ${accordionThemes.header.end('accordion_' + id, 'content_1_' + id)}
+      ${accordionThemes.content.begin('accordion_' + id, 'content_1_' + id)}
+        <div class="one-chart-configurator" data-chart-id="${id}">
           <form class="row g-3">
             <div class="col-md-4">
               <label for="darkModeInput" class="form-label">Dark mode</label>
-              <select class="form-select custom-select" aria-label="Dark mode" id="darkModeInput" onchange="changeTheme('${id}')">
-                <option value="light" >White mode</option>
+              <select class="form-select" aria-label="Dark mode" id="darkModeInput" onchange="changeTheme('${id}')">
+                <option value="light">White mode</option>
                 <option value="dark">Dark mode</option>
               </select>
             </div>
             <div class="col-md-4">
               <label for="colorSetInput" class="form-label">Categorical Color</label>
-              <select class="form-select custom-select" aria-label="Color set" id="colorSetInput" onchange="changeTheme('${id}')">
-                <option value="${ODSCharts.ODSChartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS}" >Default supporting colours</option>
-                <option value="${ODSCharts.ODSChartsCategoricalColorsSet.LIGHTER_TINTS}" >Lighter tints</option>
+              <select class="form-select" aria-label="Color set" id="colorSetInput" onchange="changeTheme('${id}')">
+                <option value="${ODSCharts.ODSChartsCategoricalColorsSet.DEFAULT_SUPPORTING_COLORS}">Default supporting colours</option>
+                <option value="${ODSCharts.ODSChartsCategoricalColorsSet.LIGHTER_TINTS}">Lighter tints</option>
                 <option value="${ODSCharts.ODSChartsCategoricalColorsSet.DARKER_TINTS}">Darker tints</option>
                 <option value="${ODSCharts.ODSChartsCategoricalColorsSet.SEQUENTIAL_BLUE}">Blue</option>
                 <option value="${ODSCharts.ODSChartsCategoricalColorsSet.SEQUENTIAL_GREEN}">Green</option>
@@ -143,117 +105,124 @@ function generateConfigurator(id, cssThemeName) {
             </div>
 
             <div class="col-md-4">
-                <label for="visualMapColorInput" class="form-label">visual Map Color</label>
-                <select class="form-select custom-select" aria-label="visual Map Color" id="visualMapColorInput" onchange="changeTheme('${id}')">
-                    <option value="blue" >Blue</option>
-                    <option value="green" >Green</option>
-                    <option value="purple" >Purple</option>
-                </select>
+              <label for="visualMapColorInput" class="form-label">visual Map Color</label>
+              <select class="form-select" aria-label="visual Map Color" id="visualMapColorInput" onchange="changeTheme('${id}')">
+                <option value="blue">Blue</option>
+                <option value="green">Green</option>
+                <option value="purple">Purple</option>
+              </select>
             </div>
-            
-            
+
             <div class="col-md-4">
-                <label for="lineStyleInput" class="form-label">Line style</label>
-                <select class="form-select custom-select" aria-label="Line style" id="lineStyleInput" onchange="changeTheme('${id}')">
-                    <option value="smooth" >Smooth</option>
-                    <option value="broken" >Broken</option>
-                    <option value="withPoints" >Broken with points</option>
-                </select>
+              <label for="lineStyleInput" class="form-label">Line style</label>
+              <select class="form-select" aria-label="Line style" id="lineStyleInput" onchange="changeTheme('${id}')">
+                <option value="smooth">Smooth</option>
+                <option value="broken">Broken</option>
+                <option value="withPoints">Broken with points</option>
+              </select>
             </div>
 
             <div class="col-md-4 pt-3">
-                <button  class="btn btn-primary mt-1" onclick="downloadTheme('${id}'); event.preventDefault()">Download theme</button>
+              <button  class="btn btn-primary mt-1" onclick="downloadTheme('${id}'); event.preventDefault()">Download theme</button>
             </div>
             <div class="col-12">
-                <h2>Optional features</h2>
+              <h2>Optional features</h2>
             </div>
-
 
             <div class="col-md-4">
-                <label for="popoverInput" class="form-label">Popover or Tooltip</label>
-                <select class="form-select custom-select" aria-label="Line style" id="popoverInput" onchange="changeTheme('${id}')">
-                    <option value="none" >None</option>
-                    <option value="popover" >Popover</option>
-                    <option value="tooltip" >Tooltip</option>
-                </select>
-            </div>          
-
-            <div class="col-md-4 popover-config">
-                <label for="popoverSharedInput" class="form-label">Tooltip/Popover content</label>
-                <select class="form-select custom-select" aria-label="Line style" id="popoverSharedInput" onchange="changeTheme('${id}')">
-                    <option value="none" >Not shared</option>
-                    <option value="shared" >Shared</option>
-                </select>
+              <label for="popoverInput" class="form-label">Popover or Tooltip</label>
+              <select class="form-select" aria-label="Line style" id="popoverInput" onchange="changeTheme('${id}')">
+                <option value="none">None</option>
+                <option value="popover">Popover</option>
+                <option value="tooltip">Tooltip</option>
+              </select>
             </div>
 
             <div class="col-md-4 popover-config">
-                <label for="popoverAxisInput" class="form-label">Tooltip/Popover axis pointer</label>
-                <select class="form-select custom-select" aria-label="Line style" id="popoverAxisInput" onchange="changeTheme('${id}')">
-                    <option value="none" >None</option>
-                    <option value="shadow" >Shadow</option>
-                    <option value="line" >Line</option>
-                    <option value="cross" >Cross</option>
-                </select>
+              <label for="popoverSharedInput" class="form-label">Tooltip/Popover content</label>
+              <select class="form-select" aria-label="Line style" id="popoverSharedInput" onchange="changeTheme('${id}')">
+                <option value="none">Not shared</option>
+                <option value="shared">Shared</option>
+              </select>
+            </div>
+
+            <div class="col-md-4 popover-config">
+              <label for="popoverAxisInput" class="form-label">Tooltip/Popover axis pointer</label>
+              <select class="form-select" aria-label="Line style" id="popoverAxisInput" onchange="changeTheme('${id}')">
+                <option value="none">None</option>
+                <option value="shadow">Shadow</option>
+                <option value="line">Line</option>
+                <option value="cross">Cross</option>
+              </select>
             </div>
 
             <div class="col-md-4 popover-renderer">
-                <label for="popoverTemplateInput" class="form-label">Popover renderer</label>
-                <select class="form-select custom-select" aria-label="Line style" id="popoverTemplateInput" onchange="changeTheme('${id}')">
-                    <option value="internal" >Chartjs renderer</option>
-                    <option value="external" >Boosted renderer</option>
-                </select>
+              <label for="popoverTemplateInput" class="form-label">Popover renderer</label>
+              <select class="form-select" aria-label="Line style" id="popoverTemplateInput" onchange="changeTheme('${id}')">
+                <option value="internal">Chartjs renderer</option>
+                <option value="external">Boosted renderer</option>
+              </select>
             </div>
 
             <div class="col-12">
               <h2>Global theme reference</h2>
             </div>
             <div class="col-md-4">
-                <label for="cssTheme" class="form-label">Used CSS</label>
-                <select class="form-select custom-select" aria-label="Line style" id="cssTheme" onchange="changeCssTheme(this.value)">
-                    <option value="NONE" >NONE</option>
-                    <option value="BOOSTED4" >Boosted 4</option>
-                    <option value="BOOSTED5" >Boosted 5</option>
-                </select>
+              <label for="cssTheme" class="form-label">Used CSS</label>
+              <select class="form-select" aria-label="Line style" id="cssTheme" onchange="changeTheme('${id}')">
+                <option value="NONE">NONE</option>
+                <option value="BOOSTED4">Boosted 4</option>
+                <option value="BOOSTED5">Boosted 5</option>
+              </select>
             </div>
           </form>
         </div>
-      ${accordionThemes[cssThemeName].content.end('accordion_' + id, 'content_1_' + id)}
-    ${accordionThemes[cssThemeName].item.end('accordion_' + id, 'content_1_' + id)}
-    ${accordionThemes[cssThemeName].item.begin('accordion_' + id, 'content_2_' + id)}
-      ${accordionThemes[cssThemeName].header.begin('accordion_' + id, 'content_2_' + id)}
+      ${accordionThemes.content.end('accordion_' + id, 'content_1_' + id)}
+    ${accordionThemes.item.end('accordion_' + id, 'content_1_' + id)}
+    ${accordionThemes.item.begin('accordion_' + id, 'content_2_' + id)}
+      ${accordionThemes.header.begin('accordion_' + id, 'content_2_' + id)}
         View code
-      ${accordionThemes[cssThemeName].header.end('accordion_' + id, 'content_2_' + id)}
-      ${accordionThemes[cssThemeName].content.begin('accordion_' + id, 'content_2_' + id)}
+      ${accordionThemes.header.end('accordion_' + id, 'content_2_' + id)}
+      ${accordionThemes.content.begin('accordion_' + id, 'content_2_' + id)}
         <div class="border border-light position-relative mt-2 p-2">
-          <div class="display-5"> HTML
-          </div>
-          <code >
-            <pre id=${id + '_html'}>
-            </pre>
+          <div class="display-5">HTML</div>
+          <code>
+            <pre id=${id + '_html'}></pre>
           </code>
         </div>
         <div class="border border-light position-relative mt-2 p-2">
-          <div class="display-5"> JavaScript / ODS Charts
-          </div>
-          <code >
-            <pre id=${id + '_code'}>
-            </pre>
+          <div class="display-5">JavaScript / ODS Charts</div>
+          <code>
+            <pre id=${id + '_code'}></pre>
           </code>
         </div>
-      ${accordionThemes[cssThemeName].content.end('accordion_' + id, 'content_2_' + id)}
-    ${accordionThemes[cssThemeName].item.end('accordion_' + id, 'content_2_' + id)}
-  ${accordionThemes[cssThemeName].accordion.end('accordion_' + id)}
+      ${accordionThemes.content.end('accordion_' + id, 'content_2_' + id)}
+    ${accordionThemes.item.end('accordion_' + id, 'content_2_' + id)}
+  ${accordionThemes.accordion.end('accordion_' + id)}
 `;
 }
 
-function generateExampleDiv(id, cssThemeName) {
+function generateExampleDiv(id) {
   var div = document.getElementById(id);
 
-  div.innerHTML = `${generateChartDiv(id)}
-  <div id="configurator_${id}" data-css-theme-name="${cssThemeName}">
-    ${generateConfigurator(id, cssThemeName)}
+  div.innerHTML = `<iframe style="width: 100%; min-height: 60vh;"></iframe>
+  <div id="configurator_${id}">
+    ${generateConfigurator(id)}
   </div>
 `;
+
+  let iframeDocument = div.querySelector('iframe').contentDocument;
+  // Firefox approach
+  iframeDocument.open();
+  iframeDocument.write(`
+<link id="mainFont" href="${themeElements.BOOSTED5.css[0]}" rel="stylesheet">
+<link id="mainCSS" cssThemeName="BOOSTED5" href="${themeElements.BOOSTED5.css[1]}" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js" integrity="sha384-o5uz97et3bErHvpKfD4Jz4n0JfhJDWABFuF4NP+iEEDxE1VwMWJ19QGR0lqFZnr6" crossorigin="anonymous"></script>
+<script type="text/javascript" src="../../dist/ods-charts.js"></script>
+<script type="text/javascript" src="./index.js"></script>
+<script id="mainJS" src="${themeElements.BOOSTED5.script[0]}"></script>
+${generateChartDiv(id)}`);
+  iframeDocument.close();
 }
 
 async function displayChart(
@@ -270,6 +239,16 @@ async function displayChart(
   cssThemeName,
   refresh = false
 ) {
+  if (!refresh) {
+    generateExampleDiv(id);
+    let iframe = document.querySelector(`#${id} iframe`);
+    while (!iframe.contentWindow.boosted && !iframe.contentWindow.ODSCharts && !iframe.contentWindow.echarts) {
+      await wait(50);
+    }
+  }
+
+  let iframe = document.querySelector(`#${id} iframe`);
+
   if (!cssThemeName) {
     cssThemeName = ODSCharts.ODSChartsCSSThemesNames.BOOSTED5;
   }
@@ -284,7 +263,7 @@ async function displayChart(
   }
   let cssTheme = ODSCharts.ODSChartsCSSThemes[cssThemeName];
 
-  var themeManager = ODSCharts.getThemeManager({
+  var themeManager = iframe.contentWindow.ODSCharts.getThemeManager({
     mode,
     categoricalColors,
     visualMapColor,
@@ -296,41 +275,41 @@ async function displayChart(
     popoverTemplateInput = ODSCharts.ODSChartsCSSThemesNames.NONE === cssThemeName ? 'internal' : 'external';
   }
 
-  const actualTheme = document.querySelector('[data-css-theme]');
-  if ((!actualTheme && 'NONE' !== cssThemeName) || (actualTheme && cssThemeName !== actualTheme.getAttribute('data-css-theme'))) {
-    for (const elt of document.querySelectorAll('[data-css-theme]')) {
-      elt.remove();
+  const actualTheme = iframe.contentDocument.getElementById('mainCSS').getAttribute('cssThemeName');
+
+  if (actualTheme !== cssThemeName) {
+    iframe.contentDocument.getElementById('mainFont').href = `${themeElements[cssThemeName].css[0] || ''}`;
+    iframe.contentDocument.getElementById('mainCSS').href = `${themeElements[cssThemeName].css[1] || ''}`;
+
+    // Recreate Boosted JS script tag inside iframe
+    iframe.contentDocument.head.removeChild(iframe.contentDocument.getElementById('mainJS'));
+    let boostedScript = iframe.contentDocument.createElement('script');
+    boostedScript.setAttribute('id', 'mainJS');
+    boostedScript.setAttribute('src', `${themeElements[cssThemeName].script[0] || ''}`);
+
+    if (actualTheme === 'BOOSTED4') {
+      iframe.contentDocument.head.removeChild(iframe.contentDocument.getElementById('jQuery'));
+      iframe.contentDocument.head.appendChild(boostedScript);
     }
-    for (const css of themeElements[cssThemeName].css) {
-      const linkElt = document.createElement('link');
-      linkElt.href = css;
-      linkElt.rel = 'stylesheet';
-      linkElt.setAttribute('crossorigin', 'anonymous');
-      linkElt.setAttribute('data-css-theme', cssThemeName);
-      document.head.appendChild(linkElt);
+
+    if (cssThemeName === 'BOOSTED4') {
+      let jQueryScript = iframe.contentDocument.createElement('script');
+      jQueryScript.setAttribute('id', 'jQuery');
+      jQueryScript.setAttribute('src', `${themeElements.BOOSTED4.script[1]}`);
+      jQueryScript.addEventListener('load', (e) => {
+        iframe.contentDocument.head.appendChild(boostedScript);
+      });
+      iframe.contentDocument.head.appendChild(jQueryScript);
+    } else {
+      iframe.contentDocument.head.appendChild(boostedScript);
     }
-    for (const script of themeElements[cssThemeName].script) {
-      const scriptElt = document.createElement('script');
-      scriptElt.src = script;
-      scriptElt.setAttribute('crossorigin', 'anonymous');
-      scriptElt.setAttribute('data-css-theme', cssThemeName);
-      document.head.appendChild(scriptElt);
-    }
+
+    iframe.contentDocument.getElementById('mainCSS').setAttribute('cssThemeName', cssThemeName);
   }
-  await wait(50);
-  if (cssThemeName !== 'NONE') {
-    while (!window.boosted) {
-      await wait(500);
-    }
-    while ('BOOSTED4' === cssThemeName && typeof $ === 'undefined') {
-      await wait(500);
-    }
-  }
-  await wait(50);
 
   var theme = themeManager.theme;
 
-  echarts.registerTheme(themeManager.name, theme);
+  iframe.contentWindow.echarts.registerTheme(themeManager.name, theme);
 
   var legends = false;
 
@@ -345,27 +324,14 @@ async function displayChart(
   var dataOptions = _.cloneDeep(options);
 
   var chartId = id + '_chart';
-  let newCSSTheme = !refresh;
   let customColorOption = undefined;
-  if (!refresh) {
-    generateExampleDiv(id, cssThemeName);
-  } else {
-    newCSSTheme = document.getElementById('configurator_' + id).getAttribute('data-css-theme-name') !== cssThemeName;
-    if (newCSSTheme) {
-      customColorOption = document.querySelector(`#configurator_${id} [data-custom-categorical-color]`);
-
-      document.getElementById('configurator_' + id).setAttribute('data-css-theme-name', cssThemeName);
-      document.getElementById('configurator_' + id).innerHTML = generateConfigurator(id, cssThemeName);
-    }
-  }
-
-  var div = document.getElementById(chartId);
+  var div = iframe.contentDocument.getElementById(chartId);
 
   if (refresh) {
-    echarts.dispose(div);
-    document.getElementById(id + '_holder').innerHTML = buildChartDiv(id);
+    iframe.contentWindow.echarts.dispose(div);
+    iframe.contentDocument.getElementById(id + '_holder').innerHTML = buildChartDiv(id);
     await wait();
-    div = document.getElementById(chartId);
+    div = iframe.contentDocument.getElementById(chartId);
   }
 
   document.getElementById(id + '_html').innerText = generateChartDiv(id);
@@ -452,7 +418,7 @@ myChart.setOption(themeManager.getChartOptions());
     themeManager,
   });
 
-  if (newCSSTheme || !refresh) {
+  if (!refresh) {
     if ('string' === typeof themeManager.options.categoricalColors) {
       document.querySelector(`#accordion_${id} #colorSetInput option[value="${themeManager.options.categoricalColors}"]`).setAttribute('selected', 'selected');
     } else {
@@ -508,13 +474,14 @@ myChart.setOption(themeManager.getChartOptions());
     elt.style.display = 'none' === popoverInput ? 'none' : 'block';
   });
 
-  var myChart = echarts.init(div, themeManager.name, {
+  var myChart = iframe.contentWindow.echarts.init(div, themeManager.name, {
     renderer: 'svg',
   });
 
   themeManager.setDataOptions(options);
   if (legends) {
-    themeManager.externalizeLegends(myChart, '#' + id + '_legend');
+    themeManager.externalizeLegends(myChart, `#${id}_legend`);
+    iframe.style.height = `calc(60vh + 2.375rem)`; // Quick fix but there is maybe other ways to fix scrollbars inside iframe
   }
   themeManager.manageChartResize(myChart, chartId);
   if ('none' !== popoverInput) {
@@ -525,26 +492,12 @@ myChart.setOption(themeManager.getChartOptions());
         tooltip: 'tooltip' === popoverInput,
         axisPointer: popoverAxisInput,
       },
-      ODSCharts.ODSChartsPopoverManagers['external' === popoverTemplateInput ? cssThemeName : ODSCharts.ODSChartsCSSThemesNames.NONE]
+      iframe.contentWindow.ODSCharts.ODSChartsPopoverManagers['external' === popoverTemplateInput ? cssThemeName : ODSCharts.ODSChartsCSSThemesNames.NONE]
     );
   }
 
   // Display the chart using the configuration items and data just specified.
   myChart.setOption(themeManager.getChartOptions());
-}
-
-async function changeCssTheme(newCss) {
-  console.log(newCss);
-  const chartIds = [];
-  document.querySelectorAll('.one-chart-configurator').forEach((elt) => {
-    const chartId = elt.getAttribute('data-chart-id');
-    chartIds.push(chartId);
-    document.querySelector(`#accordion_${chartId} #cssTheme option[value="${newCss}"]`).setAttribute('selected', 'selected');
-    document.querySelector(`#accordion_${chartId} #cssTheme option[value="${newCss}"]`).value = newCss;
-  });
-  for (const chartId of chartIds) {
-    await changeTheme(chartId);
-  }
 }
 
 async function changeTheme(id) {
@@ -575,7 +528,6 @@ async function changeTheme(id) {
   }
 }
 window.changeTheme = changeTheme;
-window.changeCssTheme = changeCssTheme;
 
 function downloadTheme(id) {
   var { themeManager } = JSON.parse(document.getElementById(id).dataset.odsExample);

--- a/docs/examples/index.js
+++ b/docs/examples/index.js
@@ -491,7 +491,7 @@ myChart.setOption(themeManager.getChartOptions());
   themeManager.setDataOptions(options);
   if (legends) {
     themeManager.externalizeLegends(myChart, `#${id}_legend`);
-    iframe.style.height = `calc(60vh + 2.375rem)`; // Quick fix but there is maybe other ways to fix scrollbars inside iframe
+    iframe.style.height = `calc(60vh + 2.375rem)`; // Fix to avoid having a vertical scrollbar within the iframe for the first rendering
   }
   themeManager.manageChartResize(myChart, chartId);
   if ('none' !== popoverInput) {

--- a/docs/examples/index.js
+++ b/docs/examples/index.js
@@ -250,7 +250,7 @@ async function displayChart(
   let iframe = document.querySelector(`#${id} iframe`);
 
   if (!cssThemeName) {
-    cssThemeName = ODSCharts.ODSChartsCSSThemesNames.BOOSTED5;
+    cssThemeName = iframe.contentWindow.ODSCharts.ODSChartsCSSThemesNames.BOOSTED5;
   }
   if (!popoverInput) {
     popoverInput = 'tooltip';
@@ -259,9 +259,9 @@ async function displayChart(
     popoverSharedInput = 'none';
   }
   if (!popoverAxisInput) {
-    popoverAxisInput = ODSCharts.ODSChartsPopoverAxisPointer.none;
+    popoverAxisInput = iframe.contentWindow.ODSCharts.ODSChartsPopoverAxisPointer.none;
   }
-  let cssTheme = ODSCharts.ODSChartsCSSThemes[cssThemeName];
+  let cssTheme = iframe.contentWindow.ODSCharts.ODSChartsCSSThemes[cssThemeName];
 
   var themeManager = iframe.contentWindow.ODSCharts.getThemeManager({
     mode,
@@ -270,9 +270,11 @@ async function displayChart(
     lineStyle,
     cssTheme,
   });
-  cssThemeName = Object.keys(ODSCharts.ODSChartsCSSThemes).find((name) => _.isEqual(ODSCharts.ODSChartsCSSThemes[name], themeManager.options.cssTheme));
+  cssThemeName = Object.keys(iframe.contentWindow.ODSCharts.ODSChartsCSSThemes).find((name) =>
+    _.isEqual(iframe.contentWindow.ODSCharts.ODSChartsCSSThemes[name], themeManager.options.cssTheme)
+  );
   if (!popoverTemplateInput) {
-    popoverTemplateInput = ODSCharts.ODSChartsCSSThemesNames.NONE === cssThemeName ? 'internal' : 'external';
+    popoverTemplateInput = iframe.contentWindow.ODSCharts.ODSChartsCSSThemesNames.NONE === cssThemeName ? 'internal' : 'external';
   }
 
   const actualTheme = iframe.contentDocument.getElementById('mainCSS').getAttribute('cssThemeName');
@@ -347,12 +349,12 @@ var dataOptions = ${JSON.stringify(options, undefined, 2)};
 ///////////////////////////////////////////////////
 // Build the theme
 var themeManager = ODSCharts.getThemeManager({
-  mode: ${'ODSCharts.ODSChartsMode.' + Object.keys(ODSCharts.ODSChartsMode).find((key) => ODSCharts.ODSChartsMode[key] === themeManager.options.mode)},
+  mode: ${'ODSCharts.ODSChartsMode.' + Object.keys(iframe.contentWindow.ODSCharts.ODSChartsMode).find((key) => iframe.contentWindow.ODSCharts.ODSChartsMode[key] === themeManager.options.mode)},
   categoricalColors: ${
     'string' === typeof themeManager.options.categoricalColors
       ? 'ODSCharts.ODSChartsCategoricalColorsSet.' +
-        Object.keys(ODSCharts.ODSChartsCategoricalColorsSet).find(
-          (key) => ODSCharts.ODSChartsCategoricalColorsSet[key] === themeManager.options.categoricalColors
+        Object.keys(iframe.contentWindow.ODSCharts.ODSChartsCategoricalColorsSet).find(
+          (key) => iframe.contentWindow.ODSCharts.ODSChartsCategoricalColorsSet[key] === themeManager.options.categoricalColors
         )
       : `[
       ${themeManager.options.categoricalColors.map((color) =>
@@ -360,7 +362,9 @@ var themeManager = ODSCharts.getThemeManager({
           ? JSON.stringify(color)
           : `{"colorPalette": ${
               'ODSCharts.ODSChartsCategoricalColorsSet.' +
-              Object.keys(ODSCharts.ODSChartsCategoricalColorsSet).find((key) => ODSCharts.ODSChartsCategoricalColorsSet[key] === color.colorPalette)
+              Object.keys(iframe.contentWindow.ODSCharts.ODSChartsCategoricalColorsSet).find(
+                (key) => iframe.contentWindow.ODSCharts.ODSChartsCategoricalColorsSet[key] === color.colorPalette
+              )
             }, "colorIndex": ${color.colorIndex}}`
       ).join(`,
       `)}
@@ -368,13 +372,17 @@ var themeManager = ODSCharts.getThemeManager({
   },
   visualMapColor:  ${
     'ODSCharts.ODSChartsSequentialColorsSet.' +
-    Object.keys(ODSCharts.ODSChartsSequentialColorsSet).find((key) => ODSCharts.ODSChartsSequentialColorsSet[key] === themeManager.options.visualMapColor)
+    Object.keys(iframe.contentWindow.ODSCharts.ODSChartsSequentialColorsSet).find(
+      (key) => iframe.contentWindow.ODSCharts.ODSChartsSequentialColorsSet[key] === themeManager.options.visualMapColor
+    )
   },
   lineStyle: ${
     'ODSCharts.ODSChartsLineStyle.' +
-    Object.keys(ODSCharts.ODSChartsLineStyle).find((key) => ODSCharts.ODSChartsLineStyle[key] === themeManager.options.lineStyle)
+    Object.keys(iframe.contentWindow.ODSCharts.ODSChartsLineStyle).find(
+      (key) => iframe.contentWindow.ODSCharts.ODSChartsLineStyle[key] === themeManager.options.lineStyle
+    )
   },
-  cssTheme: ODSCharts.ODSChartsCSSThemes.${Object.keys(ODSCharts.ODSChartsCSSThemes).find((key) => key === cssThemeName)}
+  cssTheme: ODSCharts.ODSChartsCSSThemes.${Object.keys(iframe.contentWindow.ODSCharts.ODSChartsCSSThemes).find((key) => key === cssThemeName)}
 });
 
 // register this theme to echarts
@@ -445,7 +453,9 @@ myChart.setOption(themeManager.getChartOptions());
             ? JSON.stringify(color)
             : `{"colorPalette": ${
                 'ODSCharts.ODSChartsCategoricalColorsSet.' +
-                Object.keys(ODSCharts.ODSChartsCategoricalColorsSet).find((key) => ODSCharts.ODSChartsCategoricalColorsSet[key] === color.colorPalette)
+                Object.keys(iframe.contentWindow.ODSCharts.ODSChartsCategoricalColorsSet).find(
+                  (key) => iframe.contentWindow.ODSCharts.ODSChartsCategoricalColorsSet[key] === color.colorPalette
+                )
               }, "colorIndex": ${color.colorIndex}}`
         ).join(`,
         `)}
@@ -468,7 +478,7 @@ myChart.setOption(themeManager.getChartOptions());
   }
 
   document.querySelectorAll(`#accordion_${id} .popover-renderer`).forEach((elt) => {
-    elt.style.display = ODSCharts.ODSChartsCSSThemesNames.NONE === cssThemeName || 'none' === popoverInput ? 'none' : 'block';
+    elt.style.display = iframe.contentWindow.ODSCharts.ODSChartsCSSThemesNames.NONE === cssThemeName || 'none' === popoverInput ? 'none' : 'block';
   });
   document.querySelectorAll(`#accordion_${id} .popover-config`).forEach((elt) => {
     elt.style.display = 'none' === popoverInput ? 'none' : 'block';
@@ -492,7 +502,9 @@ myChart.setOption(themeManager.getChartOptions());
         tooltip: 'tooltip' === popoverInput,
         axisPointer: popoverAxisInput,
       },
-      iframe.contentWindow.ODSCharts.ODSChartsPopoverManagers['external' === popoverTemplateInput ? cssThemeName : ODSCharts.ODSChartsCSSThemesNames.NONE]
+      iframe.contentWindow.ODSCharts.ODSChartsPopoverManagers[
+        'external' === popoverTemplateInput ? cssThemeName : iframe.contentWindow.ODSCharts.ODSChartsCSSThemesNames.NONE
+      ]
     );
   }
 

--- a/docs/examples/index.js
+++ b/docs/examples/index.js
@@ -159,7 +159,7 @@ function generateConfigurator(id) {
             <div class="col-md-4 popover-renderer">
               <label for="popoverTemplateInput" class="form-label">Popover renderer</label>
               <select class="form-select" aria-label="Line style" id="popoverTemplateInput" onchange="changeTheme('${id}')">
-                <option value="internal">Chartjs renderer</option>
+                <option value="internal">Apache ECharts renderer</option>
                 <option value="external">Boosted renderer</option>
               </select>
             </div>

--- a/docs/examples/multiple-line-chart.html
+++ b/docs/examples/multiple-line-chart.html
@@ -16,7 +16,9 @@
     <link rel="icon" href="../images/favicons/favicon.ico" />
     <meta name="msapplication-config" content="../images/favicons/browserconfig.xml" />
     <meta name="theme-color" content="#000" />
-    <!-- Here for access to maps, no logic behind -->
+    <!--
+      `ods-charts.js` is already imported by the iframe. However, it is imported here too to access the enums that are used in `index.js`.
+    -->
     <script type="text/javascript" src="../../dist/ods-charts.js"></script>
     <script type="module" src="./index.js"></script>
   </head>

--- a/docs/examples/multiple-line-chart.html
+++ b/docs/examples/multiple-line-chart.html
@@ -6,6 +6,7 @@
     <title>Multiple Line Charts - Examples - ODS Charts</title>
     <link href="https://cdn.jsdelivr.net" rel="preconnect" crossorigin="anonymous" />
     <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/orange-helvetica.min.css" rel="stylesheet" integrity="sha384-A0Qk1uKfS1i83/YuU13i2nx5pk79PkIfNFOVzTcjCMPGKIDj9Lqx9lJmV7cdBVQZ" crossorigin="anonymous" />
+    <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/boosted.min.css" rel="stylesheet" integrity="sha384-laZ3JUZ5Ln2YqhfBvadDpNyBo7w5qmWaRnnXuRwNhJeTEFuSdGbzl4ZGHAEnTozR" crossorigin="anonymous" />
     <link href="../assets/tarteaucitron-config.css" rel="stylesheet" />
     <link rel="apple-touch-icon" href="../images/favicons/apple-touch-icon.png" sizes="180x180" />
     <link rel="icon" href="../images/favicons/favicon-32x32.png" sizes="32x32" type="image/png" />
@@ -16,12 +17,7 @@
     <meta name="msapplication-config" content="../images/favicons/browserconfig.xml" />
     <meta name="theme-color" content="#000" />
 
-    <!--------------------------------------------------
-       Echarts 
-      -------------------------------------------------->
-    <script src="
-    https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js
-    "></script>
+    <!-- Here for access to maps, no logic behind -->
     <script type="text/javascript" src="../../dist/ods-charts.js"></script>
     <script type="module" src="./index.js"></script>
   </head>
@@ -71,6 +67,7 @@
         </div>
       </div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/js/boosted.bundle.min.js" integrity="sha384-3RoJImQ+Yz4jAyP6xW29kJhqJOE3rdjuu9wkNycjCuDnGAtC/crm79mLcwj1w2o/" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/tarteaucitronjs@1.17.0/tarteaucitron.min.js" integrity="sha384-g6Xxn1zA15svldHyZ/Ow+wUUeRxHf/v7eOOO2sMafcnMPFD25n80Yz/3bbhJBSoN" crossorigin="anonymous"></script>
     <script src="../assets/tarteaucitron-config.js"></script>
   </body>

--- a/docs/examples/single-line-chart.html
+++ b/docs/examples/single-line-chart.html
@@ -16,7 +16,9 @@
     <link rel="icon" href="../images/favicons/favicon.ico" />
     <meta name="msapplication-config" content="../images/favicons/browserconfig.xml" />
     <meta name="theme-color" content="#000" />
-    <!-- Here for access to maps, no logic behind -->
+    <!--
+      `ods-charts.js` is already imported by the iframe. However, it is imported here too to access the enums that are used in `index.js`.
+    -->
     <script type="text/javascript" src="../../dist/ods-charts.js"></script>
     <script type="module" src="./index.js"></script>
   </head>

--- a/docs/examples/single-line-chart.html
+++ b/docs/examples/single-line-chart.html
@@ -6,6 +6,7 @@
     <title>Single Line Charts - Examples - ODS Charts</title>
     <link href="https://cdn.jsdelivr.net" rel="preconnect" crossorigin="anonymous" />
     <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/orange-helvetica.min.css" rel="stylesheet" integrity="sha384-A0Qk1uKfS1i83/YuU13i2nx5pk79PkIfNFOVzTcjCMPGKIDj9Lqx9lJmV7cdBVQZ" crossorigin="anonymous" />
+    <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/boosted.min.css" rel="stylesheet" integrity="sha384-laZ3JUZ5Ln2YqhfBvadDpNyBo7w5qmWaRnnXuRwNhJeTEFuSdGbzl4ZGHAEnTozR" crossorigin="anonymous" />
     <link href="../assets/tarteaucitron-config.css" rel="stylesheet" />
     <link rel="apple-touch-icon" href="../images/favicons/apple-touch-icon.png" sizes="180x180" />
     <link rel="icon" href="../images/favicons/favicon-32x32.png" sizes="32x32" type="image/png" />
@@ -16,12 +17,7 @@
     <meta name="msapplication-config" content="../images/favicons/browserconfig.xml" />
     <meta name="theme-color" content="#000" />
 
-    <!--------------------------------------------------
-       Echarts 
-      -------------------------------------------------->
-    <script src="
-    https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js
-    "></script>
+    <!-- Here for access to maps, no logic behind -->
     <script type="text/javascript" src="../../dist/ods-charts.js"></script>
     <script type="module" src="./index.js"></script>
   </head>
@@ -57,6 +53,7 @@
         </div>
       </div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/js/boosted.bundle.min.js" integrity="sha384-3RoJImQ+Yz4jAyP6xW29kJhqJOE3rdjuu9wkNycjCuDnGAtC/crm79mLcwj1w2o/" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/tarteaucitronjs@1.17.0/tarteaucitron.min.js" integrity="sha384-g6Xxn1zA15svldHyZ/Ow+wUUeRxHf/v7eOOO2sMafcnMPFD25n80Yz/3bbhJBSoN" crossorigin="anonymous"></script>
     <script src="../assets/tarteaucitron-config.js"></script>
   </body>

--- a/docs/examples/stacked-bar-chart.html
+++ b/docs/examples/stacked-bar-chart.html
@@ -16,7 +16,9 @@
     <link rel="icon" href="../images/favicons/favicon.ico" />
     <meta name="msapplication-config" content="../images/favicons/browserconfig.xml" />
     <meta name="theme-color" content="#000" />
-    <!-- Here for access to maps, no logic behind -->
+    <!--
+      `ods-charts.js` is already imported by the iframe. However, it is imported here too to access the enums that are used in `index.js`.
+    -->
     <script type="text/javascript" src="../../dist/ods-charts.js"></script>
     <script type="module" src="./index.js"></script>
   </head>

--- a/docs/examples/stacked-bar-chart.html
+++ b/docs/examples/stacked-bar-chart.html
@@ -6,6 +6,7 @@
     <title>Stacked bar Charts - Examples - ODS Charts</title>
     <link href="https://cdn.jsdelivr.net" rel="preconnect" crossorigin="anonymous" />
     <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/orange-helvetica.min.css" rel="stylesheet" integrity="sha384-A0Qk1uKfS1i83/YuU13i2nx5pk79PkIfNFOVzTcjCMPGKIDj9Lqx9lJmV7cdBVQZ" crossorigin="anonymous" />
+    <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/boosted.min.css" rel="stylesheet" integrity="sha384-laZ3JUZ5Ln2YqhfBvadDpNyBo7w5qmWaRnnXuRwNhJeTEFuSdGbzl4ZGHAEnTozR" crossorigin="anonymous" />
     <link href="../assets/tarteaucitron-config.css" rel="stylesheet" />
     <link rel="apple-touch-icon" href="../images/favicons/apple-touch-icon.png" sizes="180x180" />
     <link rel="icon" href="../images/favicons/favicon-32x32.png" sizes="32x32" type="image/png" />
@@ -16,12 +17,7 @@
     <meta name="msapplication-config" content="../images/favicons/browserconfig.xml" />
     <meta name="theme-color" content="#000" />
 
-    <!--------------------------------------------------
-       Echarts 
-      -------------------------------------------------->
-    <script src="
-    https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js
-    "></script>
+    <!-- Here for access to maps, no logic behind -->
     <script type="text/javascript" src="../../dist/ods-charts.js"></script>
     <script type="module" src="./index.js"></script>
   </head>
@@ -71,6 +67,7 @@
         </div>
       </div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/js/boosted.bundle.min.js" integrity="sha384-3RoJImQ+Yz4jAyP6xW29kJhqJOE3rdjuu9wkNycjCuDnGAtC/crm79mLcwj1w2o/" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/tarteaucitronjs@1.17.0/tarteaucitron.min.js" integrity="sha384-g6Xxn1zA15svldHyZ/Ow+wUUeRxHf/v7eOOO2sMafcnMPFD25n80Yz/3bbhJBSoN" crossorigin="anonymous"></script>
     <script src="../assets/tarteaucitron-config.js"></script>
   </body>


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Closes #169

### Description

Set up examples inside iframes to isolate them from the main page CSS and JS.
Simplify a bit the index.js.
Changing the library (could be done separately) to handle larger markups.

Tried my best using webComponents to encapsulate graphs but the JS leaks outside the webcomponent and leads to issues with the js parts, that are called the number of webcomponent inside a page -> Leads to breaking accordions/tooltips, ...

Turning to iframes that encapsulate JS as well but there are some side effects with echarts and our lib right now. The remaining issue can be seen from the 2 last commits of the branch.

Should we have NONE as an option for the theme ?

### Motivation & Context

#169.
Avoid changing the CSS from the whole site to see the rendering with Boosted v4. Simplify the html and js from the doc.

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Test checklist

Please check that the following tests projects are still working:

- [ ] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [ ] `test/angular-echarts`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`
- [ ] `test/examples/timeseries-chart`
