### PR TITLE
chore(ci): add GitHub workflow to enforce Prettier check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+name: Linter
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+
+env:
+  FORCE_COLOR: 2
+  NODE: 20
+
+permissions:
+  contents: read
+
+jobs:
+  css:
+    runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]' || github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "${{ env.NODE }}"
+          cache: npm
+
+      - run: node --version
+      - run: npm --version
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Check Prettier
+        run: npm run prettier:check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Linter
+name: Prettier Check
 on:
   push:
     branches:

--- a/src/theme/common/ODS.line-style.broken.ts
+++ b/src/theme/common/ODS.line-style.broken.ts
@@ -6,10 +6,6 @@
 // This software is distributed under the MIT license.
 //
 
-
-
-
-
 export const COMMON_LINE_STYLE_BROKEN = {
   line: {
     itemStyle: {

--- a/src/theme/common/ODS.line-style.broken.ts
+++ b/src/theme/common/ODS.line-style.broken.ts
@@ -6,6 +6,10 @@
 // This software is distributed under the MIT license.
 //
 
+
+
+
+
 export const COMMON_LINE_STYLE_BROKEN = {
   line: {
     itemStyle: {


### PR DESCRIPTION
### Related issues

Closes #212

### Description

This PR adds a GitHub workflow that will enforce the Prettier formatting rules on all files in the repository:
- It will run on every push to the repository
- It will run on every pull request to the repository
- It can be run manually by anyone with write access to the repository

##### Testing

This PR came firstly with few lines added to `src/theme/common/ODS.line-style.broken.ts` in order to make the workflow fail voluntarily, as you can see at https://github.com/Orange-OpenSource/ods-charts/actions/runs/8811608553/job/24185800032?pr=214.

Confirming that everything works correctly, [this modification has been removed](https://github.com/Orange-OpenSource/ods-charts/pull/214/commits/03fe98be29f3e36b998d360bd1b9affe8e922ead), and the workflow is now green.

### Types of change

- New feature (non-breaking change which adds functionality)