### PR TITLE
249-improved-detection-of-changes-in-graph-size

### DIFF
--- a/docs/use_cases/index.html
+++ b/docs/use_cases/index.html
@@ -90,6 +90,18 @@
             </div>
           </div>
         </div>
+
+        <div class="col-12 col-lg-4 col-md-6 align-self-stretch py-2">
+          <div class="card h-100">
+            <div class="card-body">
+              <h5 class="card-title">Size management</h5>
+              <p class="card-text">The Chart may need to be redraw if it is placed in a div that changes of size.</p>
+            </div>
+            <div class="card-footer">
+              <a href="./size-management.html" class="btn btn-primary mt-3">Go to example</a>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/tarteaucitronjs@1.17.0/tarteaucitron.min.js" integrity="sha384-g6Xxn1zA15svldHyZ/Ow+wUUeRxHf/v7eOOO2sMafcnMPFD25n80Yz/3bbhJBSoN" crossorigin="anonymous"></script>

--- a/docs/use_cases/size-management.html
+++ b/docs/use_cases/size-management.html
@@ -1,0 +1,142 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Examples - Specific use cases - Size management</title>
+
+    <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/orange-helvetica.min.css" rel="stylesheet" integrity="sha384-A0Qk1uKfS1i83/YuU13i2nx5pk79PkIfNFOVzTcjCMPGKIDj9Lqx9lJmV7cdBVQZ" crossorigin="anonymous" />
+    <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/boosted.min.css" rel="stylesheet" integrity="sha384-laZ3JUZ5Ln2YqhfBvadDpNyBo7w5qmWaRnnXuRwNhJeTEFuSdGbzl4ZGHAEnTozR" crossorigin="anonymous" />
+    <link href="../assets/tarteaucitron-config.css" rel="stylesheet" />
+
+    <link rel="apple-touch-icon" href="../images/favicons/apple-touch-icon.png" sizes="180x180" />
+    <link rel="icon" href="../images/favicons/favicon-32x32.png" sizes="32x32" type="image/png" />
+    <link rel="icon" href="../images/favicons/favicon-16x16.png" sizes="16x16" type="image/png" />
+    <link rel="manifest" href="../images/favicons/manifest.json" />
+    <link rel="mask-icon" href="../images/favicons/safari-pinned-tab.svg" color="#000" />
+    <link rel="icon" href="../images/favicons/favicon.ico" />
+    <meta name="msapplication-config" content="../images/favicons/browserconfig.xml" />
+    <meta name="theme-color" content="#000" />
+    <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
+    <script type="text/javascript" src="../../dist/ods-charts.js"></script>
+    <script type="text/javascript" src="./index.js"></script>
+  </head>
+  <body>
+    <header data-bs-theme="dark">
+      <nav class="navbar navbar-expand-lg" aria-label="Global navigation">
+        <div class="container-xxl">
+          <div class="navbar-brand me-auto me-lg-4">
+            <a class="stretched-link" href="./">
+              <img src="../images/orange-logo.svg" width="50" height="50" alt="ODS Charts - Back to Home" loading="lazy" />
+            </a>
+            <h1 class="title">Orange Design System Charts</h1>
+          </div>
+        </div>
+      </nav>
+    </header>
+    <div class="title-bar">
+      <div class="container-xxl">
+        <h1 class="display-1">Size management</h1>
+      </div>
+    </div>
+    <div class="container pt-3">
+      <div class="card w-100">
+        <div class="card-body">
+          <h5 class="card-title">Collapsed graph example</h5>
+          <p class="card-text">The size of the graph may change because of window resize or just because of the DOM structure or content change, by instance if the graph is displayed in a collapsed panel.</p>
+          <p class="card-text">Apache ECharts has a <code>resize</code> method to manage that. But you can ask to the <code>ODSChartsTheme</code> to manage it for you calling the <cdoe>externalizeLegends</cdoe> method.</p>
+          <p class="card-text">
+            In the following collapsed div, we manage the resize of the div by the code:
+            <code>
+              <pre>
+                themeManager.manageChartResize(myChart, 'barLine_chart');
+              </pre>
+            </code>
+          </p>
+          <div id="htmlId">
+            <p class="d-inline-flex gap-1">
+              <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#collapseChart" aria-expanded="false" aria-controls="collapseChart">Click here to see the graph</button>
+            </p>
+            <div class="collapse" id="collapseChart">
+              <div class="card card-body">
+                <div>
+                  <div class="border border-light position-relative">
+                    <div class="chart_title">
+                      <h4 class="display-4 mx-3 mb-1 mt-3">Title</h4>
+                      <h5 class="display-5 mx-3 mb-1 mt-0">Sub-Title</h5>
+                    </div>
+                    <div id="barLine_holder">
+                      <div id="barLine_chart" style="width: 100%; height: 50vh" class="position-relative"></div>
+                    </div>
+                    <div id="barLine_legend"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <script>
+            addViewCode();
+          </script>
+        </div>
+      </div>
+      <script id="codeId">
+        ///////////////////////////////////////////////////
+        // Used data
+        ///////////////////////////////////////////////////
+
+        // Data to be displayed
+        var dataOptions = {
+          grid: {
+            left: '0%',
+            right: '0%',
+          },
+          xAxis: {
+            type: 'category',
+            data: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+          },
+          yAxis: {},
+          series: [
+            {
+              data: [10, 22, 28.8956454657, 23, 19, 15],
+              type: 'bar',
+            },
+            {
+              data: [12, 28.8956454657, 23, 15, 15, 18],
+              type: 'line',
+            },
+          ],
+          legend: {
+            data: ['label 0', 'label 1'],
+          },
+        };
+
+        ///////////////////////////////////////////////////
+        // ODS Charts
+        ///////////////////////////////////////////////////
+        // Build the theme
+        var themeManager = ODSCharts.getThemeManager();
+        echarts.registerTheme(themeManager.name, themeManager.theme);
+
+        // Get the chart holder and initiate it with the generated theme
+        var div = document.getElementById('barLine_chart');
+        var myChart = echarts.init(div, themeManager.name, {
+          renderer: 'svg',
+        });
+
+        // Set the data to be displayed.
+        themeManager.setDataOptions(dataOptions);
+        // Register the externalization of the legend.
+        themeManager.externalizeLegends(myChart, '#barLine_legend');
+        // Manage window size changed
+        themeManager.manageChartResize(myChart, 'barLine_chart');
+        // Register the externalization of the tooltip/popup
+        themeManager.externalizePopover();
+        // Display the chart using the configured theme and data.
+        myChart.setOption(themeManager.getChartOptions());
+      </script>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/js/boosted.bundle.min.js" integrity="sha384-3RoJImQ+Yz4jAyP6xW29kJhqJOE3rdjuu9wkNycjCuDnGAtC/crm79mLcwj1w2o/" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/tarteaucitronjs@1.17.0/tarteaucitron.min.js" integrity="sha384-g6Xxn1zA15svldHyZ/Ow+wUUeRxHf/v7eOOO2sMafcnMPFD25n80Yz/3bbhJBSoN" crossorigin="anonymous"></script>
+    <script src="../assets/tarteaucitron-config.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

https://github.com/Orange-OpenSource/ods-charts/issues/249

### Description

The size change detection uses the ResizeObserver if it is supported

### Motivation & Context

May need to resize for other raison than window resize

### Types of change

- New feature (non-breaking change which adds functionality)

### Test checklist

Please check that the following tests projects are still working:

- [ ] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [ ] `test/angular-echarts`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`
- [ ] `test/examples/timeseries-chart`
