### PR TITLE
Bump Apache ECharts from 5.5.0 to 5.5.1

### DIFF
--- a/docs/examples/index.js
+++ b/docs/examples/index.js
@@ -231,7 +231,7 @@ function generateExampleDiv(id) {
   iframeDocument.write(`
 <link id="mainFont" href="${themeElements.BOOSTED5.css[0]}" rel="stylesheet">
 <link id="mainCSS" cssThemeName="BOOSTED5" href="${themeElements.BOOSTED5.css[1]}" rel="stylesheet">
-<script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js" integrity="sha384-o5uz97et3bErHvpKfD4Jz4n0JfhJDWABFuF4NP+iEEDxE1VwMWJ19QGR0lqFZnr6" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/echarts@5.5.1/dist/echarts.min.js" integrity="sha384-Mx5lkUEQPM1pOJCwFtUICyX45KNojXbkWdYhkKUKsbv391mavbfoAmONbzkgYPzR" crossorigin="anonymous"></script>
 <script type="text/javascript" src="../../dist/ods-charts.js"></script>
 <script type="module" src="./index.js"></script>
 <script id="mainJS" src="${themeElements.BOOSTED5.script[0]}"></script>

--- a/docs/use_cases/add-unit.html
+++ b/docs/use_cases/add-unit.html
@@ -17,7 +17,7 @@
     <link rel="icon" href="../images/favicons/favicon.ico" />
     <meta name="msapplication-config" content="../images/favicons/browserconfig.xml" />
     <meta name="theme-color" content="#000" />
-    <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.1/dist/echarts.min.js" integrity="sha384-Mx5lkUEQPM1pOJCwFtUICyX45KNojXbkWdYhkKUKsbv391mavbfoAmONbzkgYPzR" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../../dist/ods-charts.js"></script>
     <script type="text/javascript" src="./index.js"></script>
   </head>

--- a/docs/use_cases/size-management.html
+++ b/docs/use_cases/size-management.html
@@ -17,7 +17,7 @@
     <link rel="icon" href="../images/favicons/favicon.ico" />
     <meta name="msapplication-config" content="../images/favicons/browserconfig.xml" />
     <meta name="theme-color" content="#000" />
-    <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.1/dist/echarts.min.js" integrity="sha384-Mx5lkUEQPM1pOJCwFtUICyX45KNojXbkWdYhkKUKsbv391mavbfoAmONbzkgYPzR" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../../dist/ods-charts.js"></script>
     <script type="text/javascript" src="./index.js"></script>
   </head>

--- a/docs/use_cases/specify-color.html
+++ b/docs/use_cases/specify-color.html
@@ -17,7 +17,7 @@
     <link rel="icon" href="../images/favicons/favicon.ico" />
     <meta name="msapplication-config" content="../images/favicons/browserconfig.xml" />
     <meta name="theme-color" content="#000" />
-    <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.1/dist/echarts.min.js" integrity="sha384-Mx5lkUEQPM1pOJCwFtUICyX45KNojXbkWdYhkKUKsbv391mavbfoAmONbzkgYPzR" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../../dist/ods-charts.js"></script>
     <script type="text/javascript" src="./index.js"></script>
   </head>

--- a/docs/use_cases/tooltip.html
+++ b/docs/use_cases/tooltip.html
@@ -17,7 +17,7 @@
     <link rel="icon" href="../images/favicons/favicon.ico" />
     <meta name="msapplication-config" content="../images/favicons/browserconfig.xml" />
     <meta name="theme-color" content="#000" />
-    <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.1/dist/echarts.min.js" integrity="sha384-Mx5lkUEQPM1pOJCwFtUICyX45KNojXbkWdYhkKUKsbv391mavbfoAmONbzkgYPzR" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../../dist/ods-charts.js"></script>
     <script type="text/javascript" src="./index.js"></script>
   </head>

--- a/docs/use_cases/two-colors-serie.html
+++ b/docs/use_cases/two-colors-serie.html
@@ -17,7 +17,7 @@
     <link rel="icon" href="../images/favicons/favicon.ico" />
     <meta name="msapplication-config" content="../images/favicons/browserconfig.xml" />
     <meta name="theme-color" content="#000" />
-    <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.1/dist/echarts.min.js" integrity="sha384-Mx5lkUEQPM1pOJCwFtUICyX45KNojXbkWdYhkKUKsbv391mavbfoAmONbzkgYPzR" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../../dist/ods-charts.js"></script>
     <script type="text/javascript" src="./index.js"></script>
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0-alpha.10",
       "license": "MIT",
       "devDependencies": {
-        "echarts": "^5.5.0",
+        "echarts": "^5.5.1",
         "prettier": "^3.3.2",
         "serve": "^14.2.3",
         "ts-loader": "^9.5.1",
@@ -853,13 +853,13 @@
       "dev": true
     },
     "node_modules/echarts": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.0.tgz",
-      "integrity": "sha512-rNYnNCzqDAPCr4m/fqyUFv7fD9qIsd50S6GDFgO1DxZhncCsNsG7IfUlAlvZe5oSEQxtsjnHiUuppzccry93Xw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.1.tgz",
+      "integrity": "sha512-Fce8upazaAXUVUVsjgV6mBnGuqgO+JNDlcgF79Dksy4+wgGpQB2lmYoO4TSweFg/mZITdpGHomw/cNBJZj1icA==",
       "dev": true,
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.5.0"
+        "zrender": "5.6.0"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2535,9 +2535,9 @@
       }
     },
     "node_modules/zrender": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.5.0.tgz",
-      "integrity": "sha512-O3MilSi/9mwoovx77m6ROZM7sXShR/O/JIanvzTwjN3FORfLSr81PsUGd7jlaYOeds9d8tw82oP44+3YucVo+w==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.0.tgz",
+      "integrity": "sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==",
       "dev": true,
       "dependencies": {
         "tslib": "2.3.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "watch": "webpack --watch --mode development"
   },
   "devDependencies": {
-    "echarts": "^5.5.0",
+    "echarts": "^5.5.1",
     "prettier": "^3.3.2",
     "serve": "^14.2.3",
     "ts-loader": "^9.5.1",

--- a/test/angular-echarts/package-lock.json
+++ b/test/angular-echarts/package-lock.json
@@ -16,7 +16,7 @@
         "@angular/platform-browser": "^18.0.5",
         "@angular/platform-browser-dynamic": "^18.0.5",
         "@angular/router": "^18.0.5",
-        "echarts": "^5.5.0",
+        "echarts": "^5.5.1",
         "ods-charts": "file:../..",
         "rxjs": "~7.8.0",
         "tslib": "^2.6.3",
@@ -6027,12 +6027,12 @@
       "dev": true
     },
     "node_modules/echarts": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.0.tgz",
-      "integrity": "sha512-rNYnNCzqDAPCr4m/fqyUFv7fD9qIsd50S6GDFgO1DxZhncCsNsG7IfUlAlvZe5oSEQxtsjnHiUuppzccry93Xw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.1.tgz",
+      "integrity": "sha512-Fce8upazaAXUVUVsjgV6mBnGuqgO+JNDlcgF79Dksy4+wgGpQB2lmYoO4TSweFg/mZITdpGHomw/cNBJZj1icA==",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.5.0"
+        "zrender": "5.6.0"
       }
     },
     "node_modules/echarts/node_modules/tslib": {
@@ -13048,9 +13048,9 @@
       "integrity": "sha512-0w6DGkX2BPuiK/NLf+4A8FLE43QwBfuqz2dVgi/40Rj1WmqUskCqj329O/pwrqFJLG5X8wkeG2RhIAro441xtg=="
     },
     "node_modules/zrender": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.5.0.tgz",
-      "integrity": "sha512-O3MilSi/9mwoovx77m6ROZM7sXShR/O/JIanvzTwjN3FORfLSr81PsUGd7jlaYOeds9d8tw82oP44+3YucVo+w==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.0.tgz",
+      "integrity": "sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==",
       "dependencies": {
         "tslib": "2.3.0"
       }

--- a/test/angular-echarts/package-lock.json
+++ b/test/angular-echarts/package-lock.json
@@ -40,7 +40,7 @@
       "version": "0.1.0-alpha.10",
       "license": "MIT",
       "devDependencies": {
-        "echarts": "^5.5.0",
+        "echarts": "^5.5.1",
         "prettier": "^3.3.2",
         "serve": "^14.2.3",
         "ts-loader": "^9.5.1",

--- a/test/angular-echarts/package.json
+++ b/test/angular-echarts/package.json
@@ -18,7 +18,7 @@
     "@angular/platform-browser": "^18.0.5",
     "@angular/platform-browser-dynamic": "^18.0.5",
     "@angular/router": "^18.0.5",
-    "echarts": "^5.5.0",
+    "echarts": "^5.5.1",
     "ods-charts": "file:../..",
     "rxjs": "~7.8.0",
     "tslib": "^2.6.3",

--- a/test/angular-ngx-echarts/package-lock.json
+++ b/test/angular-ngx-echarts/package-lock.json
@@ -16,7 +16,7 @@
         "@angular/platform-browser": "^18.0.5",
         "@angular/platform-browser-dynamic": "^18.0.5",
         "@angular/router": "^18.0.5",
-        "echarts": "^5.5.0",
+        "echarts": "^5.5.1",
         "ngx-echarts": "^18.0.0",
         "ods-charts": "file:../..",
         "rxjs": "~7.8.0",
@@ -6028,12 +6028,12 @@
       "dev": true
     },
     "node_modules/echarts": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.0.tgz",
-      "integrity": "sha512-rNYnNCzqDAPCr4m/fqyUFv7fD9qIsd50S6GDFgO1DxZhncCsNsG7IfUlAlvZe5oSEQxtsjnHiUuppzccry93Xw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.1.tgz",
+      "integrity": "sha512-Fce8upazaAXUVUVsjgV6mBnGuqgO+JNDlcgF79Dksy4+wgGpQB2lmYoO4TSweFg/mZITdpGHomw/cNBJZj1icA==",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.5.0"
+        "zrender": "5.6.0"
       }
     },
     "node_modules/echarts/node_modules/tslib": {
@@ -13060,9 +13060,9 @@
       "integrity": "sha512-0w6DGkX2BPuiK/NLf+4A8FLE43QwBfuqz2dVgi/40Rj1WmqUskCqj329O/pwrqFJLG5X8wkeG2RhIAro441xtg=="
     },
     "node_modules/zrender": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.5.0.tgz",
-      "integrity": "sha512-O3MilSi/9mwoovx77m6ROZM7sXShR/O/JIanvzTwjN3FORfLSr81PsUGd7jlaYOeds9d8tw82oP44+3YucVo+w==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.0.tgz",
+      "integrity": "sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==",
       "dependencies": {
         "tslib": "2.3.0"
       }

--- a/test/angular-ngx-echarts/package-lock.json
+++ b/test/angular-ngx-echarts/package-lock.json
@@ -41,7 +41,7 @@
       "version": "0.1.0-alpha.10",
       "license": "MIT",
       "devDependencies": {
-        "echarts": "^5.5.0",
+        "echarts": "^5.5.1",
         "prettier": "^3.3.2",
         "serve": "^14.2.3",
         "ts-loader": "^9.5.1",

--- a/test/angular-ngx-echarts/package.json
+++ b/test/angular-ngx-echarts/package.json
@@ -18,7 +18,7 @@
     "@angular/platform-browser": "^18.0.5",
     "@angular/platform-browser-dynamic": "^18.0.5",
     "@angular/router": "^18.0.5",
-    "echarts": "^5.5.0",
+    "echarts": "^5.5.1",
     "ngx-echarts": "^18.0.0",
     "ods-charts": "file:../..",
     "rxjs": "~7.8.0",

--- a/test/react/package-lock.json
+++ b/test/react/package-lock.json
@@ -23,7 +23,7 @@
       "version": "0.1.0-alpha.10",
       "license": "MIT",
       "devDependencies": {
-        "echarts": "^5.5.0",
+        "echarts": "^5.5.1",
         "prettier": "^3.3.2",
         "serve": "^14.2.3",
         "ts-loader": "^9.5.1",

--- a/test/react/package-lock.json
+++ b/test/react/package-lock.json
@@ -11,7 +11,7 @@
         "@testing-library/jest-dom": "^6.4.6",
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.5.2",
-        "echarts": "^5.5.0",
+        "echarts": "^5.5.1",
         "ods-charts": "file:../..",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -8036,12 +8036,12 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
     },
     "node_modules/echarts": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.0.tgz",
-      "integrity": "sha512-rNYnNCzqDAPCr4m/fqyUFv7fD9qIsd50S6GDFgO1DxZhncCsNsG7IfUlAlvZe5oSEQxtsjnHiUuppzccry93Xw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.1.tgz",
+      "integrity": "sha512-Fce8upazaAXUVUVsjgV6mBnGuqgO+JNDlcgF79Dksy4+wgGpQB2lmYoO4TSweFg/mZITdpGHomw/cNBJZj1icA==",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.5.0"
+        "zrender": "5.6.0"
       }
     },
     "node_modules/echarts/node_modules/tslib": {
@@ -22325,9 +22325,9 @@
       }
     },
     "node_modules/zrender": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.5.0.tgz",
-      "integrity": "sha512-O3MilSi/9mwoovx77m6ROZM7sXShR/O/JIanvzTwjN3FORfLSr81PsUGd7jlaYOeds9d8tw82oP44+3YucVo+w==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.0.tgz",
+      "integrity": "sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==",
       "dependencies": {
         "tslib": "2.3.0"
       }

--- a/test/react/package.json
+++ b/test/react/package.json
@@ -6,7 +6,7 @@
     "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",
-    "echarts": "^5.5.0",
+    "echarts": "^5.5.1",
     "ods-charts": "file:../..",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/test/vue/package-lock.json
+++ b/test/vue/package-lock.json
@@ -8,7 +8,7 @@
       "name": "vue",
       "version": "0.0.0",
       "dependencies": {
-        "echarts": "^5.5.0",
+        "echarts": "^5.5.1",
         "ods-charts": "file:../..",
         "vue": "^3.3.4"
       },
@@ -2371,12 +2371,12 @@
       }
     },
     "node_modules/echarts": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.0.tgz",
-      "integrity": "sha512-rNYnNCzqDAPCr4m/fqyUFv7fD9qIsd50S6GDFgO1DxZhncCsNsG7IfUlAlvZe5oSEQxtsjnHiUuppzccry93Xw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.1.tgz",
+      "integrity": "sha512-Fce8upazaAXUVUVsjgV6mBnGuqgO+JNDlcgF79Dksy4+wgGpQB2lmYoO4TSweFg/mZITdpGHomw/cNBJZj1icA==",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.5.0"
+        "zrender": "5.6.0"
       }
     },
     "node_modules/echarts/node_modules/tslib": {
@@ -4632,9 +4632,9 @@
       }
     },
     "node_modules/zrender": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.5.0.tgz",
-      "integrity": "sha512-O3MilSi/9mwoovx77m6ROZM7sXShR/O/JIanvzTwjN3FORfLSr81PsUGd7jlaYOeds9d8tw82oP44+3YucVo+w==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.0.tgz",
+      "integrity": "sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==",
       "dependencies": {
         "tslib": "2.3.0"
       }

--- a/test/vue/package-lock.json
+++ b/test/vue/package-lock.json
@@ -34,7 +34,7 @@
       "version": "0.1.0-alpha.10",
       "license": "MIT",
       "devDependencies": {
-        "echarts": "^5.5.0",
+        "echarts": "^5.5.1",
         "prettier": "^3.3.2",
         "serve": "^14.2.3",
         "ts-loader": "^9.5.1",

--- a/test/vue/package.json
+++ b/test/vue/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
-    "echarts": "^5.5.0",
+    "echarts": "^5.5.1",
     "ods-charts": "file:../..",
     "vue": "^3.3.4"
   },


### PR DESCRIPTION
Closes #289

### Description

Go through the entire list of the release note to evaluate the impacts, enhancements, etc. we can/must do in ODS Charts. Source: https://github.com/apache/echarts/releases/tag/5.5.1:

- [x] ~~**Feature** axis: support custom axis tick/label positions~~:
  - this [new `customValues` for `axisTick` and `axisLabel`](https://echarts.apache.org/en/option.html#xAxis.axisTick.customValues) doesn't have any impact on the library, since it's a new option.
  - there's no issue to create in our repository, as it's not something we could introduce by default for our rendering.
- [x] ~~**Feature** bar: add `startValue` option~~:
  - this [new `startValue` option](https://echarts.apache.org/en/option.html#yAxis.startValue) doesn't have any impact on the library, since it's a new option.
  - there's no issue to create in our repository, as it's not something we could introduce by default for our rendering.
- [x] ~~**Feature** sankey: add `itemStyle.borderRadius` option~~
  - this new option doesn't have any impact on the library, it's a new option that won't be used for our rendering as there's generally no border radius in Orange interfaces
  -  there's no issue to create in our repository, as it's not something we could introduce by default for our rendering.
- [x] ~~**Feature** time: add meridian template `{a}/{A}`~~: nothing to do in our library as this is just a new time formatting
- [x] ~~**Feature** geo: add `totalZoom` parameter for the `georoam` event~~: nothing to do as we don't use the `georoam` event
- [x] ~~**Feature** treemap: add `scaleLimit` option to limit the zooming~~: nothing to do as we don't use the Treemap.
- [x] ~~**Fix** series: avoid error caused by `seriesData.getLinkedData`~~: no impact as we don't use `seriesData.getLinkedData`
- [x] ~~**Fix** marker: fix marker label formatter can't get series information~~: nothing to do as we never experienced this issue in our tests
- [x] ~~**Fix** aria: avoid error in SSR mode~~: nothing to do as we don't use SSR mode
- [x] ~~**Fix** data: avoid error when using BigInt values~~:  nothing to do as we don't have any examples with BigInt values
- [x] ~~**Fix** pie: fix `endAngle` is not applied on the empty circle~~: nothing to do as we don't have yet pie charts. Moreover, WIP PR https://github.com/Orange-OpenSource/ods-charts/pull/88 doesn't use `endAngle`
- [x] ~~**Fix** toolbox: fix uncaught reference error in the environment that `MouseEvent` doesn't exist~~: nothing to do as we didn't experience this issue
- [x] ~~**Fix** tooltip: fix tooltip XSS issue when legend name is HTML string~~: nothing to do, the `encodeHTMLContent` when the HTML render mode is used doesn't cause any issues in our current examples using popovers (with `ODSChartsPopover`).
  - [x] No regression at https://deploy-preview-299--ods-charts.netlify.app/use_cases/tooltip 
- [x] ~~**Fix** type: fix that in users' .d.ts `import('echarts/types/dist/shared')` can not visit `'echarts/types/dist/shared.d.ts'` since v5.5.0~~: nothing to do, no direct impact on our library

I've also checked the compatibility with `angular-ngx-echarts` and didn't observe any regressions. No issues related to this new 5.5.1 is created in their repository, so it's probably already compatible.

### Test checklist

Please check that the following tests projects are still working:

- [x] `docs/examples`
- [x] `test/angular-ngx-echarts`
- [x] `test/angular-echarts`
- [x] `test/html`
- [x] `test/react`
- [x] `test/vue`
- [x] `test/examples/bar-line-chart`
- [x] `test/examples/single-line-chart`
- [x] `test/examples/timeseries-chart`
