### PR TITLE
Docs: Use `<main>` HTML tag in examples

### DIFF
--- a/docs/examples/bar-chart.html
+++ b/docs/examples/bar-chart.html
@@ -35,81 +35,83 @@
         </div>
       </nav>
     </header>
-    <div class="title-bar">
-      <div class="container-xxl">
-        <h1 class="display-1">Bar charts example</h1>
-      </div>
-    </div>
-    <div class="container d-flex flex-nowrap pt-3">
-      <div class="card w-100">
-        <div class="card-body">
-          <h5 class="card-title">Vertical bar chart</h5>
-          <p class="card-text">Used to compare related data sets.</p>
-          <div id="barChart"></div>
-          <script>
-            window.addEventListener('DOMContentLoaded', () => {
-              window.generateBarChart('barChart');
-            });
-          </script>
+    <main>
+      <div class="title-bar">
+        <div class="container-xxl">
+          <h1 class="display-1">Bar charts example</h1>
         </div>
       </div>
-    </div>
-    <div class="container d-flex flex-nowrap pt-3">
-      <div class="card w-100">
-        <div class="card-body">
-          <h5 class="card-title">Horizontal bar chart</h5>
-          <p class="card-text">Used to compare related data sets.</p>
-          <div id="barChartH"></div>
-          <script>
-            window.addEventListener('DOMContentLoaded', () => {
-              window.generateBarChart('barChartH', true);
-            });
-          </script>
+      <div class="container d-flex flex-nowrap pt-3">
+        <div class="card w-100">
+          <div class="card-body">
+            <h5 class="card-title">Vertical bar chart</h5>
+            <p class="card-text">Used to compare related data sets.</p>
+            <div id="barChart"></div>
+            <script>
+              window.addEventListener('DOMContentLoaded', () => {
+                window.generateBarChart('barChart');
+              });
+            </script>
+          </div>
         </div>
       </div>
-    </div>
-    <div class="container d-flex flex-nowrap pt-3">
-      <div class="card w-100">
-        <div class="card-body">
-          <h5 class="card-title">Vertical grouped bar chart</h5>
-          <p class="card-text">A grouped bar chart is used to compare values across multiple categories.</p>
-          <div id="barChartGV"></div>
-          <script>
-            window.addEventListener('DOMContentLoaded', () => {
-              window.generateBarChart('barChartGV', false, true);
-            });
-          </script>
+      <div class="container d-flex flex-nowrap pt-3">
+        <div class="card w-100">
+          <div class="card-body">
+            <h5 class="card-title">Horizontal bar chart</h5>
+            <p class="card-text">Used to compare related data sets.</p>
+            <div id="barChartH"></div>
+            <script>
+              window.addEventListener('DOMContentLoaded', () => {
+                window.generateBarChart('barChartH', true);
+              });
+            </script>
+          </div>
         </div>
       </div>
-    </div>
-    <div class="container d-flex flex-nowrap pt-3">
-      <div class="card w-100">
-        <div class="card-body">
-          <h5 class="card-title">Horizontal grouped bar chart</h5>
-          <p class="card-text">A grouped bar chart is used to compare values across multiple categories.</p>
-          <div id="barChartGH"></div>
-          <script>
-            window.addEventListener('DOMContentLoaded', () => {
-              window.generateBarChart('barChartGH', true, true);
-            });
-          </script>
+      <div class="container d-flex flex-nowrap pt-3">
+        <div class="card w-100">
+          <div class="card-body">
+            <h5 class="card-title">Vertical grouped bar chart</h5>
+            <p class="card-text">A grouped bar chart is used to compare values across multiple categories.</p>
+            <div id="barChartGV"></div>
+            <script>
+              window.addEventListener('DOMContentLoaded', () => {
+                window.generateBarChart('barChartGV', false, true);
+              });
+            </script>
+          </div>
         </div>
       </div>
-    </div>
-    <div class="container d-flex flex-nowrap pt-3">
-      <div class="card w-100">
-        <div class="card-body">
-          <h5 class="card-title">Grouped bar chart with dataset</h5>
-          <p class="card-text">A grouped bar chart is used to compare values across multiple categories.</p>
-          <div id="barChartdataset"></div>
-          <script>
-            window.addEventListener('DOMContentLoaded', () => {
-              window.generateDatasetBarChart('barChartdataset');
-            });
-          </script>
+      <div class="container d-flex flex-nowrap pt-3">
+        <div class="card w-100">
+          <div class="card-body">
+            <h5 class="card-title">Horizontal grouped bar chart</h5>
+            <p class="card-text">A grouped bar chart is used to compare values across multiple categories.</p>
+            <div id="barChartGH"></div>
+            <script>
+              window.addEventListener('DOMContentLoaded', () => {
+                window.generateBarChart('barChartGH', true, true);
+              });
+            </script>
+          </div>
         </div>
       </div>
-    </div>
+      <div class="container d-flex flex-nowrap pt-3">
+        <div class="card w-100">
+          <div class="card-body">
+            <h5 class="card-title">Grouped bar chart with dataset</h5>
+            <p class="card-text">A grouped bar chart is used to compare values across multiple categories.</p>
+            <div id="barChartdataset"></div>
+            <script>
+              window.addEventListener('DOMContentLoaded', () => {
+                window.generateDatasetBarChart('barChartdataset');
+              });
+            </script>
+          </div>
+        </div>
+      </div>
+    </main>
     <script src="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/js/boosted.bundle.min.js" integrity="sha384-3RoJImQ+Yz4jAyP6xW29kJhqJOE3rdjuu9wkNycjCuDnGAtC/crm79mLcwj1w2o/" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/tarteaucitronjs@1.17.0/tarteaucitron.min.js" integrity="sha384-g6Xxn1zA15svldHyZ/Ow+wUUeRxHf/v7eOOO2sMafcnMPFD25n80Yz/3bbhJBSoN" crossorigin="anonymous"></script>
     <script src="../assets/tarteaucitron-config.js"></script>

--- a/docs/examples/bar-line-chart.html
+++ b/docs/examples/bar-line-chart.html
@@ -35,39 +35,41 @@
         </div>
       </nav>
     </header>
-    <div class="title-bar">
-      <div class="container-xxl">
-        <h1 class="display-1">Bar + line charts example</h1>
-      </div>
-    </div>
-    <div class="container d-flex flex-nowrap pt-3">
-      <div class="card w-100">
-        <div class="card-body">
-          <h5 class="card-title">Bar chart and line chart</h5>
-          <p class="card-text">Two metric values showing quantity alongside changes in trends over time.</p>
-          <div id="barLine"></div>
-          <script>
-            window.addEventListener('DOMContentLoaded', () => {
-              window.generateBarLineChart('barLine', false, false, false);
-            });
-          </script>
+    <main>
+      <div class="title-bar">
+        <div class="container-xxl">
+          <h1 class="display-1">Bar + line charts example</h1>
         </div>
       </div>
-    </div>
-    <div class="container d-flex flex-nowrap pt-3">
-      <div class="card w-100">
-        <div class="card-body">
-          <h5 class="card-title">Grouped bar and line chart</h5>
-          <p class="card-text">Two metric values showing quantity alongside changes in trends over time.</p>
-          <div id="barLineGroup"></div>
-          <script>
-            window.addEventListener('DOMContentLoaded', () => {
-              window.generateBarLineChart('barLineGroup', false, true, false);
-            });
-          </script>
+      <div class="container d-flex flex-nowrap pt-3">
+        <div class="card w-100">
+          <div class="card-body">
+            <h5 class="card-title">Bar chart and line chart</h5>
+            <p class="card-text">Two metric values showing quantity alongside changes in trends over time.</p>
+            <div id="barLine"></div>
+            <script>
+              window.addEventListener('DOMContentLoaded', () => {
+                window.generateBarLineChart('barLine', false, false, false);
+              });
+            </script>
+          </div>
         </div>
       </div>
-    </div>
+      <div class="container d-flex flex-nowrap pt-3">
+        <div class="card w-100">
+          <div class="card-body">
+            <h5 class="card-title">Grouped bar and line chart</h5>
+            <p class="card-text">Two metric values showing quantity alongside changes in trends over time.</p>
+            <div id="barLineGroup"></div>
+            <script>
+              window.addEventListener('DOMContentLoaded', () => {
+                window.generateBarLineChart('barLineGroup', false, true, false);
+              });
+            </script>
+          </div>
+        </div>
+      </div>
+    </main>
     <script src="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/js/boosted.bundle.min.js" integrity="sha384-3RoJImQ+Yz4jAyP6xW29kJhqJOE3rdjuu9wkNycjCuDnGAtC/crm79mLcwj1w2o/" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/tarteaucitronjs@1.17.0/tarteaucitron.min.js" integrity="sha384-g6Xxn1zA15svldHyZ/Ow+wUUeRxHf/v7eOOO2sMafcnMPFD25n80Yz/3bbhJBSoN" crossorigin="anonymous"></script>
     <script src="../assets/tarteaucitron-config.js"></script>

--- a/docs/examples/multiple-line-chart.html
+++ b/docs/examples/multiple-line-chart.html
@@ -35,39 +35,41 @@
         </div>
       </nav>
     </header>
-    <div class="title-bar">
-      <div class="container-xxl">
-        <h1 class="display-1">Multiple line charts example</h1>
-      </div>
-    </div>
-    <div class="container d-flex flex-nowrap pt-3">
-      <div class="card w-100">
-        <div class="card-body">
-          <h5 class="card-title">Multiple line chart example</h5>
-          <p class="card-text">Compare the relationship between several values over categories.</p>
-          <div id="multipleLineChart"></div>
-          <script>
-            window.addEventListener('DOMContentLoaded', () => {
-              window.generateMultipleLineChart('multipleLineChart');
-            });
-          </script>
+    <main>
+      <div class="title-bar">
+        <div class="container-xxl">
+          <h1 class="display-1">Multiple line charts example</h1>
         </div>
       </div>
-    </div>
-    <div class="container d-flex flex-nowrap pt-3">
-      <div class="card w-100">
-        <div class="card-body">
-          <h5 class="card-title">Time series line chart example</h5>
-          <p class="card-text">Compare the relationship between several values over time.</p>
-          <div id="timeSeriesChart"></div>
-          <script>
-            window.addEventListener('DOMContentLoaded', () => {
-              window.generateTimeSeriesLineChart('timeSeriesChart');
-            });
-          </script>
+      <div class="container d-flex flex-nowrap pt-3">
+        <div class="card w-100">
+          <div class="card-body">
+            <h5 class="card-title">Multiple line chart example</h5>
+            <p class="card-text">Compare the relationship between several values over categories.</p>
+            <div id="multipleLineChart"></div>
+            <script>
+              window.addEventListener('DOMContentLoaded', () => {
+                window.generateMultipleLineChart('multipleLineChart');
+              });
+            </script>
+          </div>
         </div>
       </div>
-    </div>
+      <div class="container d-flex flex-nowrap pt-3">
+        <div class="card w-100">
+          <div class="card-body">
+            <h5 class="card-title">Time series line chart example</h5>
+            <p class="card-text">Compare the relationship between several values over time.</p>
+            <div id="timeSeriesChart"></div>
+            <script>
+              window.addEventListener('DOMContentLoaded', () => {
+                window.generateTimeSeriesLineChart('timeSeriesChart');
+              });
+            </script>
+          </div>
+        </div>
+      </div>
+    </main>
     <script src="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/js/boosted.bundle.min.js" integrity="sha384-3RoJImQ+Yz4jAyP6xW29kJhqJOE3rdjuu9wkNycjCuDnGAtC/crm79mLcwj1w2o/" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/tarteaucitronjs@1.17.0/tarteaucitron.min.js" integrity="sha384-g6Xxn1zA15svldHyZ/Ow+wUUeRxHf/v7eOOO2sMafcnMPFD25n80Yz/3bbhJBSoN" crossorigin="anonymous"></script>
     <script src="../assets/tarteaucitron-config.js"></script>

--- a/docs/examples/single-line-chart.html
+++ b/docs/examples/single-line-chart.html
@@ -35,25 +35,27 @@
         </div>
       </nav>
     </header>
-    <div class="title-bar">
-      <div class="container-xxl">
-        <h1 class="display-1">Single line charts example</h1>
-      </div>
-    </div>
-    <div class="container d-flex flex-nowrap pt-3">
-      <div class="card w-100">
-        <div class="card-body">
-          <h5 class="card-title">Single line chart example</h5>
-          <p class="card-text">A single line chart is used to show the change of values over a continuous time interval or time span.</p>
-          <div id="singleLineChart"></div>
-          <script>
-            window.addEventListener('DOMContentLoaded', () => {
-              window.generateSingleLineChart('singleLineChart');
-            });
-          </script>
+    <main>
+      <div class="title-bar">
+        <div class="container-xxl">
+          <h1 class="display-1">Single line charts example</h1>
         </div>
       </div>
-    </div>
+      <div class="container d-flex flex-nowrap pt-3">
+        <div class="card w-100">
+          <div class="card-body">
+            <h5 class="card-title">Single line chart example</h5>
+            <p class="card-text">A single line chart is used to show the change of values over a continuous time interval or time span.</p>
+            <div id="singleLineChart"></div>
+            <script>
+              window.addEventListener('DOMContentLoaded', () => {
+                window.generateSingleLineChart('singleLineChart');
+              });
+            </script>
+          </div>
+        </div>
+      </div>
+    </main>
     <script src="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/js/boosted.bundle.min.js" integrity="sha384-3RoJImQ+Yz4jAyP6xW29kJhqJOE3rdjuu9wkNycjCuDnGAtC/crm79mLcwj1w2o/" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/tarteaucitronjs@1.17.0/tarteaucitron.min.js" integrity="sha384-g6Xxn1zA15svldHyZ/Ow+wUUeRxHf/v7eOOO2sMafcnMPFD25n80Yz/3bbhJBSoN" crossorigin="anonymous"></script>
     <script src="../assets/tarteaucitron-config.js"></script>

--- a/docs/examples/stacked-bar-chart.html
+++ b/docs/examples/stacked-bar-chart.html
@@ -35,39 +35,41 @@
         </div>
       </nav>
     </header>
-    <div class="title-bar">
-      <div class="container-xxl">
-        <h1 class="display-1">Stacked bar charts example</h1>
-      </div>
-    </div>
-    <div class="container d-flex flex-nowrap pt-3">
-      <div class="card w-100">
-        <div class="card-body">
-          <h5 class="card-title">Vertical stacked bar chart</h5>
-          <p class="card-text">Compare proportional contributions within a category.</p>
-          <div id="barChartSV"></div>
-          <script>
-            window.addEventListener('DOMContentLoaded', () => {
-              window.generateBarChart('barChartSV', false, true, true);
-            });
-          </script>
+    <main>
+      <div class="title-bar">
+        <div class="container-xxl">
+          <h1 class="display-1">Stacked bar charts example</h1>
         </div>
       </div>
-    </div>
-    <div class="container d-flex flex-nowrap pt-3">
-      <div class="card w-100">
-        <div class="card-body">
-          <h5 class="card-title">Horizontal stacked bar chart</h5>
-          <p class="card-text">Compare proportional contributions within a category.</p>
-          <div id="barChartSH"></div>
-          <script>
-            window.addEventListener('DOMContentLoaded', () => {
-              window.generateBarChart('barChartSH', true, true, true);
-            });
-          </script>
+      <div class="container d-flex flex-nowrap pt-3">
+        <div class="card w-100">
+          <div class="card-body">
+            <h5 class="card-title">Vertical stacked bar chart</h5>
+            <p class="card-text">Compare proportional contributions within a category.</p>
+            <div id="barChartSV"></div>
+            <script>
+              window.addEventListener('DOMContentLoaded', () => {
+                window.generateBarChart('barChartSV', false, true, true);
+              });
+            </script>
+          </div>
         </div>
       </div>
-    </div>
+      <div class="container d-flex flex-nowrap pt-3">
+        <div class="card w-100">
+          <div class="card-body">
+            <h5 class="card-title">Horizontal stacked bar chart</h5>
+            <p class="card-text">Compare proportional contributions within a category.</p>
+            <div id="barChartSH"></div>
+            <script>
+              window.addEventListener('DOMContentLoaded', () => {
+                window.generateBarChart('barChartSH', true, true, true);
+              });
+            </script>
+          </div>
+        </div>
+      </div>
+    </main>
     <script src="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/js/boosted.bundle.min.js" integrity="sha384-3RoJImQ+Yz4jAyP6xW29kJhqJOE3rdjuu9wkNycjCuDnGAtC/crm79mLcwj1w2o/" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/tarteaucitronjs@1.17.0/tarteaucitron.min.js" integrity="sha384-g6Xxn1zA15svldHyZ/Ow+wUUeRxHf/v7eOOO2sMafcnMPFD25n80Yz/3bbhJBSoN" crossorigin="anonymous"></script>
     <script src="../assets/tarteaucitron-config.js"></script>


### PR DESCRIPTION
### Description

This PR simply adds a `<main>` HTML tags in all `docs/examples/*` for more semantics.

It has been done in https://github.com/Orange-OpenSource/ods-charts/pull/88/files, but this PR should be merged before for consistency throughout the examples.