### PR TITLE
feat(lib)!: Simplify API, removal of the distinction between classic and heatmap color sets

### DIFF
--- a/docs/examples/index.js
+++ b/docs/examples/index.js
@@ -113,23 +113,6 @@ function generateConfigurator(id) {
             </div>
 
             <div class="col-md-4">
-              <label for="visualMapColorInput" class="form-label">Visual Map Colors</label>
-              <select class="form-select" aria-label="Visual Map Colors" id="visualMapColorInput" onchange="changeTheme('${id}')">
-                <option value="${ODSCharts.ODSChartsColorsSet.DEFAULT}">Default colors (12)</option>
-                <option value="${ODSCharts.ODSChartsColorsSet.CATEGORICAL}">Categorical colors (12)</option>
-                <option value="${ODSCharts.ODSChartsColorsSet.FUNCTIONAL}">Functional (6)</option>
-                <option value="${ODSCharts.ODSChartsColorsSet.SUPPORTING_COLORS}">Supporting colors (5)</option>
-                <option value="${ODSCharts.ODSChartsColorsSet.LIGHTER_TINTS}">Lighter tints (5)</option>
-                <option value="${ODSCharts.ODSChartsColorsSet.DARKER_TINTS}">Darker tints (5)</option>
-                <option value="${ODSCharts.ODSChartsColorsSet.SEQUENTIAL_BLUE}">Blue (6)</option>
-                <option value="${ODSCharts.ODSChartsColorsSet.SEQUENTIAL_GREEN}">Green (6)</option>
-                <option value="${ODSCharts.ODSChartsColorsSet.SEQUENTIAL_PINK}">Pink (6)</option>
-                <option value="${ODSCharts.ODSChartsColorsSet.SEQUENTIAL_PURPLE}">Purple (6)</option>
-                <option value="${ODSCharts.ODSChartsColorsSet.SEQUENTIAL_YELLOW}">Yellow (6)</option>
-              </select>
-            </div>
-
-            <div class="col-md-4">
               <label for="lineStyleInput" class="form-label">Line style</label>
               <select class="form-select" id="lineStyleInput" onchange="changeTheme('${id}')">
                 <option value="smooth">Smooth</option>
@@ -271,7 +254,6 @@ async function displayChart(
   options,
   mode,
   colors,
-  visualMapColor,
   lineStyle,
   rendererInput,
   popoverInput,
@@ -322,7 +304,6 @@ async function displayChart(
   var themeManager = iframe.contentWindow.ODSCharts.getThemeManager({
     mode,
     colors,
-    visualMapColor,
     lineStyle,
     cssTheme,
   });
@@ -495,12 +476,6 @@ var themeManager = ODSCharts.getThemeManager({
       `)}
     ]`
   },
-  visualMapColor:  ${
-    'ODSCharts.ODSChartsColorsSet.' +
-    Object.keys(iframe.contentWindow.ODSCharts.ODSChartsColorsSet).find(
-      (key) => iframe.contentWindow.ODSCharts.ODSChartsColorsSet[key] === themeManager.options.visualMapColor
-    )
-  },
   lineStyle: ${
     'ODSCharts.ODSChartsLineStyle.' +
     Object.keys(iframe.contentWindow.ODSCharts.ODSChartsLineStyle).find(
@@ -595,7 +570,6 @@ myChart.setOption(themeManager.getChartOptions());
     }
 
     document.querySelector(`#accordion_${id} #darkModeInput option[value="${themeManager.options.mode}"]`).setAttribute('selected', 'selected');
-    document.querySelector(`#accordion_${id} #visualMapColorInput option[value="${themeManager.options.visualMapColor}"]`).setAttribute('selected', 'selected');
     document.querySelector(`#accordion_${id} #lineStyleInput option[value="${themeManager.options.lineStyle}"]`).setAttribute('selected', 'selected');
     document.querySelector(`#accordion_${id} #rendererInput option[value="${rendererInput}"]`).setAttribute('selected', 'selected');
     document.querySelector(`#accordion_${id} #popoverInput option[value="${popoverInput}"]`).setAttribute('selected', 'selected');
@@ -653,7 +627,6 @@ async function changeTheme(id) {
     11 === document.querySelector(`#accordion_${id} #colorSetInput`).selectedIndex
       ? JSON.parse(document.querySelector(`#accordion_${id} #colorSetInput`).value)
       : document.querySelector(`#accordion_${id} #colorSetInput`).value,
-    document.querySelector(`#accordion_${id} #visualMapColorInput`).value,
     document.querySelector(`#accordion_${id} #lineStyleInput`).value,
     document.querySelector(`#accordion_${id} #rendererInput`).value,
     document.querySelector(`#accordion_${id} #popoverInput`).value,
@@ -737,7 +710,7 @@ window.generateMultipleLineChart = async (id) => {
       { data: [26, 12, 14, 10, 20, 26], type: 'line' },
     ],
   };
-  displayChart(id, option, undefined, ODSCharts.ODSChartsColorsSet.DEFAULT, undefined, ODSCharts.ODSChartsLineStyle.BROKEN);
+  displayChart(id, option, undefined, ODSCharts.ODSChartsColorsSet.DEFAULT, ODSCharts.ODSChartsLineStyle.BROKEN);
 };
 
 window.generateTimeSeriesLineChart = async (id) => {
@@ -820,7 +793,7 @@ window.generateTimeSeriesLineChart = async (id) => {
       },
     ],
   };
-  displayChart(id, option, undefined, ODSCharts.ODSChartsColorsSet.DEFAULT, undefined, ODSCharts.ODSChartsLineStyle.BROKEN);
+  displayChart(id, option, undefined, ODSCharts.ODSChartsColorsSet.DEFAULT, ODSCharts.ODSChartsLineStyle.BROKEN);
 };
 
 window.generateBarChart = async (id, horizontal = false, grouped = false, stacked = false) => {
@@ -992,7 +965,7 @@ window.generateBarLineChart = async (id, horizontal = false, grouped = false, st
             colorIndex: 0,
           },
         ],
-    undefined,
+
     ODSCharts.ODSChartsLineStyle.BROKEN_WITH_POINTS
   );
 };

--- a/src/theme/ods-chart-theme.ts
+++ b/src/theme/ods-chart-theme.ts
@@ -181,12 +181,6 @@ export interface ODSChartsThemeOptions {
    */
   colors?: ODSChartsColorsSet | ODSChartsCustomColor[];
   /**
-   * visualMapColor is the set of colors to be used if map graphs (like Heatmap)
-   *
-   * Default visualMapColor is {@link ODSChartsColorsSet.SEQUENTIAL_BLUE}
-   */
-  visualMapColor?: ODSChartsColorsSet;
-  /**
    * lineStyle specifies the style of line in lineCharts.
    *
    * It can be {@link ODSChartsLineStyle.BROKEN}, {@link ODSChartsLineStyle.SMOOTH} of {@link ODSChartsLineStyle.BROKEN_WITH_POINTS}.
@@ -553,9 +547,6 @@ export class ODSChartsTheme {
     if (!options.colors) {
       options.colors = ODSChartsColorsSet.DEFAULT;
     }
-    if (!options.visualMapColor) {
-      options.visualMapColor = ODSChartsColorsSet.SEQUENTIAL_BLUE;
-    }
     if (!options.lineStyle) {
       options.lineStyle = ODSChartsLineStyle.SMOOTH;
     }
@@ -565,9 +556,7 @@ export class ODSChartsTheme {
     if (!options.cssSelector) {
       options.cssSelector = 'body';
     }
-    var themeName = `ods.${getStringValue(mode)}.${getStringValue(options.colors)}.${getStringValue(options.visualMapColor)}.${getStringValue(
-      options.lineStyle
-    )}`;
+    var themeName = `ods.${getStringValue(mode)}.${getStringValue(options.colors)}.${getStringValue(options.lineStyle)}`;
 
     const theme: EChartsProject = cloneDeepObject(ODS_PROJECT);
 
@@ -577,16 +566,18 @@ export class ODSChartsTheme {
 
     if (typeof options.colors === 'string') {
       mergeObjects(theme, cloneDeepObject(THEMES[mode].colors[options.colors]));
+      mergeObjects(theme, cloneDeepObject(THEMES[mode].visualMapColors[options.colors]));
     } else {
       mergeObjects(
         theme,
         cloneDeepObject({
           color: options.colors.map((color) => ('string' === typeof color ? color : THEMES[mode].colors[color.colorPalette].color[color.colorIndex])),
+          visualMapColor: options.colors.map((color) =>
+            'string' === typeof color ? color : THEMES[mode].visualMapColors[color.colorPalette].visualMapColor[color.colorIndex]
+          ),
         })
       );
     }
-
-    mergeObjects(theme, cloneDeepObject(THEMES[mode].visualMapColors[options.visualMapColor]));
 
     mergeObjects(theme, cloneDeepObject(THEMES[mode].linesStyle[options.lineStyle]));
 

--- a/test/angular-echarts/src/app/graph/graph.component.ts
+++ b/test/angular-echarts/src/app/graph/graph.component.ts
@@ -42,7 +42,6 @@ export class GraphComponent implements AfterViewInit {
     this.myTheme = ODSCharts.getThemeManager({
       mode: ODSCharts.ODSChartsMode.LIGHT,
       colors: ODSCharts.ODSChartsColorsSet.DARKER_TINTS,
-      visualMapColor: ODSCharts.ODSChartsColorsSet.SEQUENTIAL_BLUE,
       lineStyle: ODSCharts.ODSChartsLineStyle.SMOOTH,
     });
 

--- a/test/angular-echarts/src/app/line-chart/line-chart.component.ts
+++ b/test/angular-echarts/src/app/line-chart/line-chart.component.ts
@@ -59,7 +59,6 @@ export class LineChartComponent implements AfterViewInit {
     const lineChartODSTheme = ODSCharts.getThemeManager({
       mode: ODSCharts.ODSChartsMode.DARK,
       colors: ODSCharts.ODSChartsColorsSet.DARKER_TINTS,
-      visualMapColor: ODSCharts.ODSChartsColorsSet.SEQUENTIAL_BLUE,
       lineStyle: ODSCharts.ODSChartsLineStyle.BROKEN_WITH_POINTS,
     });
 

--- a/test/angular-ng-boosted/src/app/pages/ods-charts/ods-charts.component.ts
+++ b/test/angular-ng-boosted/src/app/pages/ods-charts/ods-charts.component.ts
@@ -130,13 +130,11 @@ export class OdsChartsComponent {
     this.myTheme1 = ODSCharts.getThemeManager({
       mode: this.currentMode === 'light' ? ODSCharts.ODSChartsMode.LIGHT : ODSCharts.ODSChartsMode.DARK,
       colors: ODSCharts.ODSChartsColorsSet.SEQUENTIAL_BLUE,
-      visualMapColor: ODSCharts.ODSChartsColorsSet.SEQUENTIAL_BLUE,
       lineStyle: ODSCharts.ODSChartsLineStyle.SMOOTH,
     });
     this.myTheme2 = ODSCharts.getThemeManager({
       mode: this.currentMode === 'light' ? ODSCharts.ODSChartsMode.LIGHT : ODSCharts.ODSChartsMode.DARK,
       colors: ODSCharts.ODSChartsColorsSet.DARKER_TINTS,
-      visualMapColor: ODSCharts.ODSChartsColorsSet.SEQUENTIAL_BLUE,
       lineStyle: ODSCharts.ODSChartsLineStyle.SMOOTH,
     });
   }

--- a/test/angular-ngx-echarts/src/app/graph/graph.component.ts
+++ b/test/angular-ngx-echarts/src/app/graph/graph.component.ts
@@ -61,7 +61,6 @@ export class GraphComponent {
     this.myTheme = ODSCharts.getThemeManager({
       mode: ODSCharts.ODSChartsMode.LIGHT,
       colors: ODSCharts.ODSChartsColorsSet.DARKER_TINTS,
-      visualMapColor: ODSCharts.ODSChartsColorsSet.SEQUENTIAL_BLUE,
       lineStyle: ODSCharts.ODSChartsLineStyle.SMOOTH,
     });
   }

--- a/test/examples/bar-line-chart/index.html
+++ b/test/examples/bar-line-chart/index.html
@@ -65,7 +65,6 @@
               colorIndex: 0,
             },
           ],
-          visualMapColor: ODSCharts.ODSChartsColorsSet.SEQUENTIAL_BLUE,
           lineStyle: ODSCharts.ODSChartsLineStyle.BROKEN_WITH_POINTS,
           cssTheme: ODSCharts.ODSChartsCSSThemes.NONE,
         });

--- a/test/examples/single-line-chart/index.html
+++ b/test/examples/single-line-chart/index.html
@@ -45,7 +45,6 @@
         var themeManager = ODSCharts.getThemeManager({
           mode: ODSCharts.ODSChartsMode.LIGHT,
           colors: ODSCharts.ODSChartsColorsSet.SEQUENTIAL_PURPLE,
-          visualMapColor: ODSCharts.ODSChartsColorsSet.SEQUENTIAL_BLUE,
           lineStyle: ODSCharts.ODSChartsLineStyle.SMOOTH,
           cssTheme: ODSCharts.ODSChartsCSSThemes.NONE,
         });

--- a/test/examples/timeseries-chart/index.html
+++ b/test/examples/timeseries-chart/index.html
@@ -2161,7 +2161,6 @@
         var themeManager = ODSCharts.getThemeManager({
           mode: ODSCharts.ODSChartsMode.LIGHT,
           colors: ODSCharts.ODSChartsColorsSet.DEFAULT,
-          visualMapColor: ODSCharts.ODSChartsColorsSet.SEQUENTIAL_BLUE,
           lineStyle: ODSCharts.ODSChartsLineStyle.BROKEN,
           cssTheme: ODSCharts.ODSChartsCSSThemes.NONE,
         });

--- a/test/html/index.html
+++ b/test/html/index.html
@@ -18,7 +18,6 @@
       var lineChartODSTheme = ODSCharts.getThemeManager({
         mode: ODSCharts.ODSChartsMode.LIGHT,
         colors: ODSCharts.ODSChartsColorsSet.DEFAULT,
-        visualMapColor: ODSCharts.ODSChartsColorsSet.SEQUENTIAL_BLUE,
         lineStyle: ODSCharts.ODSChartsLineStyle.SMOOTH,
       });
       echarts.registerTheme(lineChartODSTheme.name, lineChartODSTheme.theme);

--- a/test/react/src/LineChartComponent.js
+++ b/test/react/src/LineChartComponent.js
@@ -52,7 +52,6 @@ class LineChartComponent extends Component {
     const lineChartODSTheme = ODSCharts.getThemeManager({
       mode: ODSCharts.ODSChartsMode.DARK,
       colors: ODSCharts.ODSChartsColorsSet.DARKER_TINTS,
-      visualMapColor: ODSCharts.ODSChartsColorsSet.SEQUENTIAL_BLUE,
       lineStyle: ODSCharts.ODSChartsLineStyle.BROKEN_WITH_POINTS,
     });
 

--- a/test/vue/src/components/LineChartComponent.vue
+++ b/test/vue/src/components/LineChartComponent.vue
@@ -51,7 +51,6 @@ onMounted(() => {
   const lineChartODSTheme = ODSCharts.getThemeManager({
     mode: ODSCharts.ODSChartsMode.DARK,
     colors: ODSCharts.ODSChartsColorsSet.DARKER_TINTS,
-    visualMapColor: ODSCharts.ODSChartsColorsSet.SEQUENTIAL_BLUE,
     lineStyle: ODSCharts.ODSChartsLineStyle.BROKEN_WITH_POINTS
   })
 


### PR DESCRIPTION

### Related issues

### Description

When initializing an ODS Carts theme, the is no more 2 set of colours but only one both for colors and visualMapColors

### Motivation & Context

Simplification as only one set was used simultaneously

### Types of change

- Breaking change (fix or feature that would change existing functionality)

### Test checklist

Please check that the following tests projects are still working:

- [ ] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [ ] `test\angular-ng-boosted`
- [ ] `test/angular-echarts`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`
- [ ] `test/examples/timeseries-chart`
