### PR TITLE
fix(doc): The Y-axis at the top of some graphs on the tooltip example page was missing a little space.

### DIFF
--- a/docs/use_cases/tooltip.html
+++ b/docs/use_cases/tooltip.html
@@ -335,7 +335,7 @@ tooltip: {
               grid: {
                 left: 0,
                 right: 0,
-                top: 5,
+                top: 10,
                 bottom: 0,
                 containLabel: true,
               },
@@ -418,7 +418,7 @@ tooltip: {
               grid: {
                 left: 0,
                 right: 0,
-                top: 5,
+                top: 10,
                 bottom: 0,
                 containLabel: true,
               },
@@ -508,7 +508,7 @@ tooltip: {
               grid: {
                 left: 0,
                 right: 0,
-                top: 5,
+                top: 10,
                 bottom: 0,
                 containLabel: true,
               },
@@ -590,7 +590,7 @@ tooltip: {
               grid: {
                 left: 0,
                 right: 0,
-                top: 5,
+                top: 10,
                 bottom: 0,
                 containLabel: true,
               },


### PR DESCRIPTION
… page was missing a little space.

_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

N/A

### Description

The Y-axis at the top of some graphs on the tooltip example page was missing a little space.

![image](https://github.com/user-attachments/assets/a1b6e8ec-e2ea-4d18-9102-f4ae31c9245d)




### Motivation & Context

Display full number on axis:
![image](https://github.com/user-attachments/assets/df681dae-ab8d-45a6-888a-ce6cb3161ef1)



### Types of change

- Bug fix (non-breaking which fixes an issue)

### Test checklist

Please check that the following tests projects are still working:

- [X] `docs/examples`
