### PR TITLE
fix(lib): The second color of the same color chart was not suitable for the dark theme mode.

### DIFF
--- a/docs/assets/color-mode.js
+++ b/docs/assets/color-mode.js
@@ -25,7 +25,9 @@
     }
     document.documentElement.setAttribute('data-bs-theme', theme);
     document.querySelectorAll('iframe').forEach((iframe) => {
-      iframe.contentDocument.body.setAttribute('data-bs-theme', theme);
+      if (iframe && iframe.contentDocument && iframe.contentDocument.body) {
+        iframe.contentDocument.body.setAttribute('data-bs-theme', theme);
+      }
     });
   };
 

--- a/docs/colors/index.html
+++ b/docs/colors/index.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Colors sset - ODS Charts</title>
+
+    <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/orange-helvetica.min.css" rel="stylesheet" integrity="sha384-A0Qk1uKfS1i83/YuU13i2nx5pk79PkIfNFOVzTcjCMPGKIDj9Lqx9lJmV7cdBVQZ" crossorigin="anonymous" />
+    <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/boosted.min.css" rel="stylesheet" integrity="sha384-laZ3JUZ5Ln2YqhfBvadDpNyBo7w5qmWaRnnXuRwNhJeTEFuSdGbzl4ZGHAEnTozR" crossorigin="anonymous" />
+    <link href="../assets/tarteaucitron-config.css" rel="stylesheet" />
+    <link href="../assets/style.css" rel="stylesheet" />
+
+    <link rel="apple-touch-icon" href="../images/favicons/apple-touch-icon.png" sizes="180x180" />
+    <link rel="icon" href="../images/favicons/favicon-32x32.png" sizes="32x32" type="image/png" />
+    <link rel="icon" href="../images/favicons/favicon-16x16.png" sizes="16x16" type="image/png" />
+    <link rel="manifest" href="../images/favicons/manifest.json" />
+    <link rel="mask-icon" href="../images/favicons/safari-pinned-tab.svg" color="#000" />
+    <link rel="icon" href="../images/favicons/favicon.ico" />
+    <meta name="msapplication-config" content="../images/favicons/browserconfig.xml" />
+    <meta name="theme-color" content="#000" />
+    <script>
+      if (document.location.href.endsWith('/colors')) {
+        document.location.href = document.location.href + '/';
+      }
+    </script>
+    <script type="text/javascript" src="../../dist/ods-charts.js"></script>
+    <script type="text/javascript" src="./index.js"></script>
+    <script type="text/javascript" src="../assets/color-mode.js"></script>
+  </head>
+  <body>
+    <header class="sticky-top" data-bs-theme="dark">
+      <nav class="navbar navbar-expand-lg" aria-label="Global navigation">
+        <div class="container-xxl">
+          <div class="navbar-brand me-auto">
+            <a class="stretched-link" href="../">
+              <img src="../images/orange-logo.svg" width="50" height="50" alt="ODS Charts - Back to Home" loading="lazy" />
+            </a>
+            <h1 class="title">Orange Design System Charts</h1>
+          </div>
+          <div id="global-header" class="navbar-collapse d-lg-flex collapse show">
+            <ul class="navbar-nav flex-row">
+              <li class="nav-item dropdown">
+                <button class="nav-link nav-icon dropdown-toggle" id="bd-theme" aria-expanded="false" data-bs-toggle="dropdown" data-bs-display="static" aria-label="Toggle mode (auto)">
+                  <svg class="theme-icon-active"><use href="../images/ods-charts-icons.svg#ui-auto-mode"></use></svg>
+                  <span class="d-lg-none ms-2" id="bd-theme-text">Toggle mode</span>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-end mb-2" aria-labelledby="bd-theme-text">
+                  <li>
+                    <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="light" aria-pressed="false">
+                      <svg class="me-2"><use href="../images/ods-charts-icons.svg#ui-light-mode"></use></svg>
+                      Light
+                      <svg class="ms-auto d-none"><use href="../images/ods-charts-icons.svg#check2"></use></svg>
+                    </button>
+                  </li>
+                  <li>
+                    <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="dark" aria-pressed="false">
+                      <svg class="me-2"><use href="../images/ods-charts-icons.svg#ui-dark-mode"></use></svg>
+                      Dark
+                      <svg class="ms-auto d-none"><use href="../images/ods-charts-icons.svg#check2"></use></svg>
+                    </button>
+                  </li>
+                  <li>
+                    <button type="button" class="dropdown-item d-flex align-items-center active" data-bs-theme-value="auto" aria-pressed="true">
+                      <svg class="me-2"><use href="../images/ods-charts-icons.svg#ui-auto-mode"></use></svg>
+                      Auto
+                      <svg class="ms-auto d-none"><use href="../images/ods-charts-icons.svg#check2"></use></svg>
+                    </button>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </nav>
+    </header>
+    <div class="title-bar">
+      <div class="container-xxl">
+        <h1 class="display-1">ODS Charts colors sets</h1>
+      </div>
+    </div>
+    <div class="container">
+      <div class="row" id="container"></div>
+    </div>
+    <script>
+      displayAllColorSets();
+      addThemeObserver();
+    </script>
+
+    <footer class="footer navbar mt-5" data-bs-theme="dark">
+      <h2 class="visually-hidden">Sitemap & information</h2>
+      <div class="container-xxl footer-terms">
+        <ul class="navbar-nav gap-md-3">
+          <li class="fw-bold">© Orange 2024</li>
+          <li><a class="nav-link" href="javascript:tarteaucitron.userInterface.openPanel();">Cookies</a></li>
+          <li><a class="nav-link" href="https://github.com/Orange-OpenSource/ods-charts/blob/main/LICENSE" target="blank" rel="license noopener">License</a></li>
+        </ul>
+      </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/js/boosted.bundle.min.js" integrity="sha384-3RoJImQ+Yz4jAyP6xW29kJhqJOE3rdjuu9wkNycjCuDnGAtC/crm79mLcwj1w2o/" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/tarteaucitronjs@1.17.0/tarteaucitron.min.js" integrity="sha384-g6Xxn1zA15svldHyZ/Ow+wUUeRxHf/v7eOOO2sMafcnMPFD25n80Yz/3bbhJBSoN" crossorigin="anonymous"></script>
+    <script src="../assets/tarteaucitron-config.js"></script>
+  </body>
+</html>

--- a/docs/colors/index.html
+++ b/docs/colors/index.html
@@ -78,11 +78,30 @@
         <h1 class="display-1">ODS Charts colors sets</h1>
       </div>
     </div>
-    <div class="container">
-      <div class="row" id="container"></div>
+    <div>
+      <div class="container-fluid">
+        <div class="container">
+          <h2 class="pt-3 h1">Default mode theme</h2>
+          <div class="row" id="container"></div>
+        </div>
+      </div>
+      <div data-bs-theme="light" class="container-fluid">
+        <div class="container">
+          <h2 class="pt-3 h1">Light mode theme</h2>
+          <div class="row" id="containerLight"></div>
+        </div>
+      </div>
+      <div data-bs-theme="dark" class="container-fluid">
+        <div class="container">
+          <h2 class="pt-3 h1">Dark mode theme</h2>
+          <div class="row" id="containerDark"></div>
+        </div>
+      </div>
     </div>
     <script>
-      displayAllColorSets();
+      displayAllColorSets('container');
+      displayAllColorSets('containerLight');
+      displayAllColorSets('containerDark');
       addThemeObserver();
     </script>
 

--- a/docs/colors/index.js
+++ b/docs/colors/index.js
@@ -9,12 +9,12 @@ function colorIsDark(bgColor) {
   return r * 0.299 + g * 0.587 + b * 0.114 <= 186;
 }
 
-function displayColorSet(colorSet, colorSetLabel) {
-  const theme = ODSCharts.getThemeManager({ colors: ODSCharts.ODSChartsColorsSet[colorSet], cssSelector: '#' + colorSet });
+function displayColorSet(containerId, colorSet, colorSetLabel) {
+  const theme = ODSCharts.getThemeManager({ colors: ODSCharts.ODSChartsColorsSet[colorSet], cssSelector: '#' + containerId + colorSet });
   const initialColors = theme.initialTheme.color;
   const colors = theme.theme.color;
 
-  document.getElementById(colorSet).innerHTML = `
+  document.getElementById(containerId + colorSet).innerHTML = `
   ${initialColors
     .map((color, index) => {
       const textColor = colorIsDark(colors[index]) ? 'var(--bs-white)' : 'var(--bs-black)';
@@ -34,11 +34,14 @@ function displayColorSet(colorSet, colorSetLabel) {
     `;
 
   if (colorSetLabel) {
-    document.getElementById(colorSet).previousSibling.previousSibling.previousSibling.previousSibling.innerHTML = colorSetLabel + ' (' + colors.length + ')';
+    document
+      .getElementById(containerId + colorSet)
+      .closest('.card-body')
+      .querySelector('h3').innerHTML = colorSetLabel + ' (' + colors.length + ')';
   }
 }
 
-function displayAllColorSets() {
+function displayAllColorSets(divId) {
   var sets = [
     ['DEFAULT', 'Default colors'],
     ['CATEGORICAL', 'Categorical colors'],
@@ -52,15 +55,15 @@ function displayAllColorSets() {
     ['SEQUENTIAL_PURPLE', 'Purple'],
     ['SEQUENTIAL_YELLOW', 'Yellow'],
   ];
-  document.getElementById('container').innerHTML = sets
+  document.getElementById(divId).innerHTML = sets
     .map(
       (element) => `
   <div class="col-12 col-lg-4 col-md-6 align-self-stretch py-2">
       <div class="card h-100">
         <div class="card-body">
-          <h5 class="h3">${element[1]}</h5>
-          <h6 class="card-subtitle">ODSCharts.<br />&nbsp;&nbsp;ODSChartsColorsSet.<br />&nbsp;&nbsp;&nbsp;&nbsp;${element[0]}</h6>
-          <div id="${element[0]}"></div>
+          <h3 class="h3">${element[1]}</h3>
+          <h4 class="card-subtitle">ODSCharts.<br />&nbsp;&nbsp;ODSChartsColorsSet.<br />&nbsp;&nbsp;&nbsp;&nbsp;${element[0]}</h4>
+          <div id="${divId + element[0]}"></div>
         </div>
       </div>
     </div>
@@ -69,7 +72,7 @@ function displayAllColorSets() {
     )
     .join('');
   sets.forEach((element) => {
-    displayColorSet(element[0], element[1]);
+    displayColorSet(divId, element[0], element[1]);
   });
 }
 
@@ -79,7 +82,17 @@ function addThemeObserver() {
     div = div.closest('[data-bs-theme]') || undefined;
     if (div) {
       const observer = new MutationObserver(() => {
-        displayAllColorSets();
+        displayAllColorSets('container');
+
+        if ('light' === div.getAttribute('data-bs-theme')) {
+          document.getElementById('containerLight').closest('.container-fluid').classList.add('d-none');
+          document.getElementById('containerDark').closest('.container-fluid').classList.remove('d-none');
+          document.getElementById('container').closest('.container').querySelector('h2').innerHTML = 'Default light mode theme';
+        } else {
+          document.getElementById('containerDark').closest('.container-fluid').classList.add('d-none');
+          document.getElementById('containerLight').closest('.container-fluid').classList.remove('d-none');
+          document.getElementById('container').closest('.container').querySelector('h2').innerHTML = 'Default dark mode theme';
+        }
       });
       observer.observe(div, { attributes: true, childList: false, subtree: false });
     }

--- a/docs/colors/index.js
+++ b/docs/colors/index.js
@@ -1,0 +1,88 @@
+function colorIsDark(bgColor) {
+  let color = bgColor.charAt(0) === '#' ? bgColor.substring(1, 7) : bgColor;
+  if (color.length === 3) {
+    color = color[0] + color[0] + color[1] + color[1] + color[2] + color[2];
+  }
+  let r = parseInt(color.substring(0, 2), 16); // hexToR
+  let g = parseInt(color.substring(2, 4), 16); // hexToG
+  let b = parseInt(color.substring(4, 6), 16); // hexToB
+  return r * 0.299 + g * 0.587 + b * 0.114 <= 186;
+}
+
+function displayColorSet(colorSet, colorSetLabel) {
+  const theme = ODSCharts.getThemeManager({ colors: ODSCharts.ODSChartsColorsSet[colorSet], cssSelector: '#' + colorSet });
+  const initialColors = theme.initialTheme.color;
+  const colors = theme.theme.color;
+
+  document.getElementById(colorSet).innerHTML = `
+  ${initialColors
+    .map((color, index) => {
+      const textColor = colorIsDark(colors[index]) ? 'var(--bs-white)' : 'var(--bs-black)';
+
+      return `
+     <div style="color: ${textColor}; background-color: ${colors[index]}" class="pt-3 px-2 mb-2">
+  <p class="h5 text-center">
+    <span>Index ${index}</span>
+    </p>
+    <div class="text-start" style="font-size: smaller;">${color}</div>
+    <div class="text-end pb-1">${colors[index]}</div>
+</div>
+    `;
+    })
+    .join('')}
+   
+    `;
+
+  if (colorSetLabel) {
+    document.getElementById(colorSet).previousSibling.previousSibling.previousSibling.previousSibling.innerHTML = colorSetLabel + ' (' + colors.length + ')';
+  }
+}
+
+function displayAllColorSets() {
+  var sets = [
+    ['DEFAULT', 'Default colors'],
+    ['CATEGORICAL', 'Categorical colors'],
+    ['FUNCTIONAL', 'Functional'],
+    ['SUPPORTING_COLORS', 'Supporting colors'],
+    ['LIGHTER_TINTS', 'Lighter tints'],
+    ['DARKER_TINTS', 'Darker tints'],
+    ['SEQUENTIAL_BLUE', 'Blue'],
+    ['SEQUENTIAL_GREEN', 'Green'],
+    ['SEQUENTIAL_PINK', 'Pink'],
+    ['SEQUENTIAL_PURPLE', 'Purple'],
+    ['SEQUENTIAL_YELLOW', 'Yellow'],
+  ];
+  document.getElementById('container').innerHTML = sets
+    .map(
+      (element) => `
+  <div class="col-12 col-lg-4 col-md-6 align-self-stretch py-2">
+      <div class="card h-100">
+        <div class="card-body">
+          <h5 class="h3">${element[1]}</h5>
+          <h6 class="card-subtitle">ODSCharts.<br />&nbsp;&nbsp;ODSChartsColorsSet.<br />&nbsp;&nbsp;&nbsp;&nbsp;${element[0]}</h6>
+          <div id="${element[0]}"></div>
+        </div>
+      </div>
+    </div>
+  
+  `
+    )
+    .join('');
+  sets.forEach((element) => {
+    displayColorSet(element[0], element[1]);
+  });
+}
+
+function addThemeObserver() {
+  let div = document.getElementById('container');
+  if (div && MutationObserver) {
+    div = div.closest('[data-bs-theme]') || undefined;
+    if (div) {
+      const observer = new MutationObserver(() => {
+        displayAllColorSets();
+      });
+      observer.observe(div, { attributes: true, childList: false, subtree: false });
+    }
+  }
+  return div;
+}

--- a/docs/colors/index.js
+++ b/docs/colors/index.js
@@ -6,7 +6,15 @@ function colorIsDark(bgColor) {
   let r = parseInt(color.substring(0, 2), 16); // hexToR
   let g = parseInt(color.substring(2, 4), 16); // hexToG
   let b = parseInt(color.substring(4, 6), 16); // hexToB
-  return r * 0.299 + g * 0.587 + b * 0.114 <= 186;
+  let uicolors = [r / 255, g / 255, b / 255];
+  let c = uicolors.map((col) => {
+    if (col <= 0.03928) {
+      return col / 12.92;
+    }
+    return Math.pow((col + 0.055) / 1.055, 2.4);
+  });
+  let L = 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2];
+  return L <= 0.179;
 }
 
 function displayColorSet(containerId, colorSet, colorSetLabel) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -118,6 +118,20 @@
             </div>
           </div>
         </div>
+
+        <div class="col-12 col-lg-4 col-md-6 align-self-stretch py-2">
+          <div class="card h-100">
+            <div class="card-body">
+              <h5 class="card-title">Colors sets</h5>
+              <h6 class="card-subtitle">ODS Charts available colors</h6>
+              <p class="card-text">Display the set of colors available in ODS Charts.</p>
+            </div>
+
+            <div class="card-footer">
+              <a href="colors/" class="btn btn-primary mt-3">Color sets</a>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/src/theme/colors/colors-css-variables.ts
+++ b/src/theme/colors/colors-css-variables.ts
@@ -234,28 +234,28 @@ const NON_BOOSTED5_VARIABLE = `
   --ods-yellow-6: var(--ods-yellow-600);
 
   --ods-blue-1: var(--ods-blue-100);
-  --ods-blue-1: var(--ods-blue-100);
+  --ods-blue-2: var(--ods-blue-200);
   --ods-blue-3: var(--ods-blue-300);
   --ods-blue-4: var(--ods-blue-400);
   --ods-blue-5: var(--ods-blue-500);
   --ods-blue-6: var(--ods-blue-600);
 
   --ods-green-1: var(--ods-green-100);
-  --ods-green-1: var(--ods-green-100);
+  --ods-green-2: var(--ods-green-200);
   --ods-green-3: var(--ods-green-300);
   --ods-green-4: var(--ods-green-400);
   --ods-green-5: var(--ods-green-500);
   --ods-green-6: var(--ods-green-600);
 
   --ods-pink-1: var(--ods-pink-100);
-  --ods-pink-1: var(--ods-pink-100);
+  --ods-pink-2: var(--ods-pink-200);
   --ods-pink-3: var(--ods-pink-300);
   --ods-pink-4: var(--ods-pink-400);
   --ods-pink-5: var(--ods-pink-500);
   --ods-pink-6: var(--ods-pink-600);
 
   --ods-purple-1: var(--ods-purple-100);
-  --ods-purple-1: var(--ods-purple-100);
+  --ods-purple-2: var(--ods-purple-200);
   --ods-purple-3: var(--ods-purple-300);
   --ods-purple-4: var(--ods-purple-400);
   --ods-purple-5: var(--ods-purple-500);


### PR DESCRIPTION
### Related issues

next to issue #534 

### Description

Add a page to display the set of colors available in ODS Charts

Doing so detect the bug :  The second color of the one color set was not suitable for the dark theme mode.

### Motivation & Context

Display, fix and check color sets

### Types of change

- Bug fix 
- New feature 

### Test checklist

Please check that the following tests projects are still working:

- [ ] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [ ] `test\angular-ng-boosted`
- [ ] `test/angular-echarts`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`
- [ ] `test/examples/timeseries-chart`
