### PR TITLE
fix(lib): dark/light mode change partially done when using ODSCharts popover renderer

### DIFF
--- a/src/theme/popover/ods-chart-popover.ts
+++ b/src/theme/popover/ods-chart-popover.ts
@@ -288,7 +288,7 @@ export class ODSChartsPopover {
       style.textContent = DEFAULT_NONE_CSS;
       document.head.appendChild(style);
     }
-    const popoverOptions = {};
+    const popoverOptions: any = {};
     const tooltipTrigger: 'xAxis' | 'yAxis' | 'grid' = this.getTooltipTrigger(dataOptions, themeOptions);
     this.enterable = !!dataOptions && !!dataOptions.tooltip && !!dataOptions.tooltip.enterable;
 
@@ -386,7 +386,7 @@ export class ODSChartsPopover {
             hideDelay: 0,
             appendTo: 'body',
             renderMode: 'html',
-            className: `ods-charts-popover ods-charts-enterable-${this.enterable ? 'true' : 'false'} ods-charts-mode-${this.mode} ${ODSChartsItemCSSDefinition.getClasses(cssTheme.popover?.odsChartsPopover)}`,
+            className: `ods-charts-popover ods-charts-enterable-${this.enterable ? 'true' : 'false'} ${ODSChartsItemCSSDefinition.getClasses(cssTheme.popover?.odsChartsPopover)}`,
             axisPointer: {
               type: this.popoverConfig.axisPointer,
             },
@@ -454,15 +454,21 @@ export class ODSChartsPopover {
         });
       }
 
+      if (popoverOptions?.tooltip?.formatter) {
+        popoverOptions.tooltip.formatter.IsOdsChartsFormatter = true;
+      }
+
       // We have to delete any default formatter as it is incompatible with externalizePopover feature
       if (dataOptions?.tooltip?.formatter) {
-        dataOptions.tooltip = cloneDeepObject(dataOptions.tooltip);
-        // But if no formatter has been provided through the popoverDefinition,
-        // we will use the Apache ECharts config
-        if (!this.popoverDefinition.getPopupContentValue) {
-          const formatter = dataOptions.tooltip.formatter;
-          this.popoverDefinition = cloneDeepObject(this.popoverDefinition);
-          this.popoverDefinition.getPopupContentValue = (tooltipElement: ODSChartsPopoverItem) => formatter([tooltipElement]);
+        if (!dataOptions.tooltip.formatter.IsOdsChartsFormatter) {
+          dataOptions.tooltip = cloneDeepObject(dataOptions.tooltip);
+          // But if no formatter has been provided through the popoverDefinition,
+          // we will use the Apache ECharts config
+          if (!this.popoverDefinition.getPopupContentValue) {
+            const formatter = dataOptions.tooltip.formatter;
+            this.popoverDefinition = cloneDeepObject(this.popoverDefinition);
+            this.popoverDefinition.getPopupContentValue = (tooltipElement: ODSChartsPopoverItem) => formatter([tooltipElement]);
+          }
         }
         delete dataOptions.tooltip.formatter;
       }


### PR DESCRIPTION
### Related issues

https://github.com/Orange-OpenSource/ods-charts/issues/540

### Description

- classes added at the top level of the Apache Echarts popover container are not changed after a switch of dark or light theme mode. This dark or light mode must not be changed at this top level

- A provide formatter may be used to diplay popover content. But after a dark or light mode, the generated formatter must not be consider as user providded one.


### Motivation & Context

1. Popover not readable after them mode switch
![keep_preivous_container_mode](https://github.com/user-attachments/assets/53af7e05-c4ac-423f-aeba-ea66692d7572)

2. Popover content replace by `[object HtmlDivElement]` after a mode switch
![content_replace_after_switch](https://github.com/user-attachments/assets/cd3fb83b-6d48-45ba-a0af-ae7805a03ca6)


### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix

### Test checklist

Please check that the following tests projects are still working:

- [ ] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [x] `test\angular-ng-boosted`
- [ ] `test/angular-echarts`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`
- [ ] `test/examples/timeseries-chart`
