### PR TITLE
docs: add CSS, dark/light mode and popover theme use cases

### DIFF
--- a/docs/use_cases/add-unit.html
+++ b/docs/use_cases/add-unit.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Examples - Specific use cases - Add unit</title>
+    <title>Add unit - Specific use cases - ODS Charts</title>
 
     <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/orange-helvetica.min.css" rel="stylesheet" integrity="sha384-A0Qk1uKfS1i83/YuU13i2nx5pk79PkIfNFOVzTcjCMPGKIDj9Lqx9lJmV7cdBVQZ" crossorigin="anonymous" />
     <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/boosted.min.css" rel="stylesheet" integrity="sha384-laZ3JUZ5Ln2YqhfBvadDpNyBo7w5qmWaRnnXuRwNhJeTEFuSdGbzl4ZGHAEnTozR" crossorigin="anonymous" />

--- a/docs/use_cases/index.html
+++ b/docs/use_cases/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Examples - Specific use cases</title>
+    <title>Specific use cases - ODS Charts</title>
 
     <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/orange-helvetica.min.css" rel="stylesheet" integrity="sha384-A0Qk1uKfS1i83/YuU13i2nx5pk79PkIfNFOVzTcjCMPGKIDj9Lqx9lJmV7cdBVQZ" crossorigin="anonymous" />
     <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/boosted.min.css" rel="stylesheet" integrity="sha384-laZ3JUZ5Ln2YqhfBvadDpNyBo7w5qmWaRnnXuRwNhJeTEFuSdGbzl4ZGHAEnTozR" crossorigin="anonymous" />
@@ -159,6 +159,19 @@
             </div>
             <div class="card-footer">
               <a href="./time-slider.html" class="btn btn-primary mt-3">Go to use case</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-12 col-lg-4 col-md-6 align-self-stretch py-2">
+          <div class="card h-100">
+            <div class="card-body">
+              <h5 class="card-title">Theme</h5>
+              <p class="card-text">For the moment, ODS Charts supports 3 CSS themes : Boosted 5, Boosted 4 and a minimalist CSS theme embedded in ODS Charts.</p>
+              <p class="card-text">For popover/tooltip management, it also support both renderer from Boosted 5 or 4 and renderer from Apache Echarts.</p>
+            </div>
+            <div class="card-footer">
+              <a href="./theme.html" class="btn btn-primary mt-3">Go to use case</a>
             </div>
           </div>
         </div>

--- a/docs/use_cases/legends-holders.html
+++ b/docs/use_cases/legends-holders.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Examples - Specific use cases - Specific legend holders</title>
+    <title>Specific legend holders - Specific use cases - ODS Charts</title>
 
     <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/orange-helvetica.min.css" rel="stylesheet" integrity="sha384-A0Qk1uKfS1i83/YuU13i2nx5pk79PkIfNFOVzTcjCMPGKIDj9Lqx9lJmV7cdBVQZ" crossorigin="anonymous" />
     <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/boosted.min.css" rel="stylesheet" integrity="sha384-laZ3JUZ5Ln2YqhfBvadDpNyBo7w5qmWaRnnXuRwNhJeTEFuSdGbzl4ZGHAEnTozR" crossorigin="anonymous" />

--- a/docs/use_cases/size-management.html
+++ b/docs/use_cases/size-management.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Examples - Specific use cases - Size management</title>
+    <title>Size management - Specific use cases - ODS Charts</title>
 
     <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/orange-helvetica.min.css" rel="stylesheet" integrity="sha384-A0Qk1uKfS1i83/YuU13i2nx5pk79PkIfNFOVzTcjCMPGKIDj9Lqx9lJmV7cdBVQZ" crossorigin="anonymous" />
     <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/boosted.min.css" rel="stylesheet" integrity="sha384-laZ3JUZ5Ln2YqhfBvadDpNyBo7w5qmWaRnnXuRwNhJeTEFuSdGbzl4ZGHAEnTozR" crossorigin="anonymous" />

--- a/docs/use_cases/specify-color.html
+++ b/docs/use_cases/specify-color.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Examples - Specific use cases - Specific series color</title>
+    <title>Specific series color - Specific use cases - ODS Charts</title>
 
     <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/orange-helvetica.min.css" rel="stylesheet" integrity="sha384-A0Qk1uKfS1i83/YuU13i2nx5pk79PkIfNFOVzTcjCMPGKIDj9Lqx9lJmV7cdBVQZ" crossorigin="anonymous" />
     <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/boosted.min.css" rel="stylesheet" integrity="sha384-laZ3JUZ5Ln2YqhfBvadDpNyBo7w5qmWaRnnXuRwNhJeTEFuSdGbzl4ZGHAEnTozR" crossorigin="anonymous" />

--- a/docs/use_cases/theme.html
+++ b/docs/use_cases/theme.html
@@ -243,7 +243,7 @@ themeManager.manageThemeObserver(myChart);
   <div class="card-body">
     <h3 class="card-title">Global <span class="text-primary">Boosted</span> theme for <u>CSS</u> but <span class="text-primary">Apache Echarts</span> for <u>popover renderer</u></h5>
     <p>
-      Let's change the previous use case to keep Boosted 5 as css theme but let's use Apache Echarts javascript to display popover/tooltip by changing the second argument of the <code>externalizePopover()</code> feature of the theme manager:
+      Let's change the previous use case to keep Boosted 5 as CSS theme but let's use Apache Echarts javascript to display popover/tooltip by changing the second argument of the <code>externalizePopover()</code> feature of the theme manager:
       <code>
         <pre>
   themeManager.externalizePopover({},

--- a/docs/use_cases/theme.html
+++ b/docs/use_cases/theme.html
@@ -81,7 +81,7 @@
           <p class="card-text">The most common use case should be using Boosted framework and its theme.</p>
           <p class="card-text">
             To do so, the <code>getThemeManager()</code> has one 
-            <code>cssTheme</code> option that allow you to specify the css theme used:
+            <code>cssTheme</code> option that allows you to specify the css theme used:
             <code>
               <pre>
 cssTheme: ODSCharts.ODSChartsCSSThemes.BOOSTED5,

--- a/docs/use_cases/theme.html
+++ b/docs/use_cases/theme.html
@@ -100,7 +100,7 @@ cssTheme: ODSCharts.ODSChartsCSSThemes.BOOSTED5,
         </code>
           </p>
           <p>To choose between light or dark mode, you use the <code>cssSelector</code> option of <code>getThemeManager()</code>. 
-            It must give an html selector of an HTML element where the chart is displayed:
+            It must give an HTML selector of an HTML element where the chart is displayed:
             <code>
               <pre>
 cssSelector: '#barLineGroup_chart'

--- a/docs/use_cases/theme.html
+++ b/docs/use_cases/theme.html
@@ -78,7 +78,7 @@
       <div class="card w-100">
         <div class="card-body">
           <h3 class="card-title">Global <span class="text-primary">Boosted</span> theme for <u>CSS</u> and <u>popover renderer</u></h5>
-          <p class="card-text">The must common use case should be using Boosted framework and its theme. </p>
+          <p class="card-text">The most common use case should be using Boosted framework and its theme.</p>
           <p class="card-text">
             To do so, the <code>getThemeManager()</code> has one 
             <code>cssTheme</code> option that allow you to specify the css theme used:

--- a/docs/use_cases/theme.html
+++ b/docs/use_cases/theme.html
@@ -384,7 +384,7 @@ var dataOptions = {
     <h3 class="card-title"><span class="text-primary">ODS Charts</span> embedded <u>CSS</u> theme and <span class="text-primary">Apache Echarts</span> <u>popover renderer</u></h5>
     <p>
       Some ODS Charts usage may be independent from Boosted. For that, ODS Charts has a minimal CSS embedded. 
-      To use it, change the  do so, the <code>cssTheme</code> option of <code>getThemeManager()</code> with:
+      To use it, change the <code>cssTheme</code> option of <code>getThemeManager()</code> with:
       <code>
         <pre>
 cssTheme: ODSCharts.ODSChartsCSSThemes.NONE,

--- a/docs/use_cases/theme.html
+++ b/docs/use_cases/theme.html
@@ -383,7 +383,7 @@ var dataOptions = {
   <div class="card-body">
     <h3 class="card-title"><span class="text-primary">ODS Charts</span> embedded <u>CSS</u> theme and <span class="text-primary">Apache Echarts</span> <u>popover renderer</u></h5>
     <p>
-      Som ODS Charts usage may be independant from Boosted. For that, ODS Charts has a minimal css embedded. 
+      Some ODS Charts usage may be independent from Boosted. For that, ODS Charts has a minimal CSS embedded. 
       To use it, change the  do so, the <code>cssTheme</code> option of <code>getThemeManager()</code> with:
       <code>
         <pre>

--- a/docs/use_cases/theme.html
+++ b/docs/use_cases/theme.html
@@ -1,0 +1,542 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Theme use cases - Specific use cases - ODS Charts</title>
+
+    <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/orange-helvetica.min.css" rel="stylesheet" integrity="sha384-A0Qk1uKfS1i83/YuU13i2nx5pk79PkIfNFOVzTcjCMPGKIDj9Lqx9lJmV7cdBVQZ" crossorigin="anonymous" />
+    <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/boosted.min.css" rel="stylesheet" integrity="sha384-laZ3JUZ5Ln2YqhfBvadDpNyBo7w5qmWaRnnXuRwNhJeTEFuSdGbzl4ZGHAEnTozR" crossorigin="anonymous" />
+    <link href="../assets/tarteaucitron-config.css" rel="stylesheet" />
+    <link href="../assets/style.css" rel="stylesheet" />
+
+    <link rel="apple-touch-icon" href="../images/favicons/apple-touch-icon.png" sizes="180x180" />
+    <link rel="icon" href="../images/favicons/favicon-32x32.png" sizes="32x32" type="image/png" />
+    <link rel="icon" href="../images/favicons/favicon-16x16.png" sizes="16x16" type="image/png" />
+    <link rel="manifest" href="../images/favicons/manifest.json" />
+    <link rel="mask-icon" href="../images/favicons/safari-pinned-tab.svg" color="#000" />
+    <link rel="icon" href="../images/favicons/favicon.ico" />
+    <meta name="msapplication-config" content="../images/favicons/browserconfig.xml" />
+    <meta name="theme-color" content="#000" />
+    <script src="https://cdn.jsdelivr.net/npm/echarts@5.6.0/dist/echarts.min.js" integrity="sha384-pPi0zxBAoDu6+JXW/C68UZLvBUUtU+7zonhif43rqj7pxsGyqyqzcian2Rj37Rss" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="../../dist/ods-charts.js"></script>
+    <script type="text/javascript" src="./index.js"></script>
+    <script type="text/javascript" src="../assets/color-mode.js"></script>
+  </head>
+  <body>
+    <header class="sticky-top" data-bs-theme="dark">
+      <nav class="navbar navbar-expand-lg" aria-label="Global navigation">
+        <div class="container-xxl">
+          <div class="navbar-brand me-auto">
+            <a class="stretched-link" href="./">
+              <img src="../images/orange-logo.svg" width="50" height="50" alt="ODS Charts - Back to Home" loading="lazy" />
+            </a>
+            <h1 class="title">Orange Design System Charts</h1>
+          </div>
+          <div id="global-header" class="navbar-collapse d-lg-flex collapse show">
+            <ul class="navbar-nav flex-row">
+              <li class="nav-item dropdown">
+                <button class="nav-link nav-icon dropdown-toggle" id="bd-theme" aria-expanded="false" data-bs-toggle="dropdown" data-bs-display="static" aria-label="Toggle mode (auto)">
+                  <svg class="theme-icon-active"><use href="../images/ods-charts-icons.svg#ui-auto-mode"></use></svg>
+                  <span class="d-lg-none ms-2" id="bd-theme-text">Toggle mode</span>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-end mb-2" aria-labelledby="bd-theme-text">
+                  <li>
+                    <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="light" aria-pressed="false">
+                      <svg class="me-2"><use href="../images/ods-charts-icons.svg#ui-light-mode"></use></svg>
+                      Light
+                      <svg class="ms-auto d-none"><use href="../images/ods-charts-icons.svg#check2"></use></svg>
+                    </button>
+                  </li>
+                  <li>
+                    <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="dark" aria-pressed="false">
+                      <svg class="me-2"><use href="../images/ods-charts-icons.svg#ui-dark-mode"></use></svg>
+                      Dark
+                      <svg class="ms-auto d-none"><use href="../images/ods-charts-icons.svg#check2"></use></svg>
+                    </button>
+                  </li>
+                  <li>
+                    <button type="button" class="dropdown-item d-flex align-items-center active" data-bs-theme-value="auto" aria-pressed="true">
+                      <svg class="me-2"><use href="../images/ods-charts-icons.svg#ui-auto-mode"></use></svg>
+                      Auto
+                      <svg class="ms-auto d-none"><use href="../images/ods-charts-icons.svg#check2"></use></svg>
+                    </button>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </nav>
+    </header>
+    <div class="title-bar">
+      <div class="container-xxl">
+        <h1 class="display-1">Theme use cases</h1>
+      </div>
+    </div>
+    <div class="container pt-3">
+      <div class="card w-100">
+        <div class="card-body">
+          <h3 class="card-title">Global <span class="text-primary">Boosted</span> theme for <u>CSS</u> and <u>popover renderer</u></h5>
+          <p class="card-text">The must common use case should be using Boosted framework and its theme. </p>
+          <p class="card-text">
+            To do so, the <code>getThemeManager()</code> has one 
+            <code>cssTheme</code> option that allow you to specify the css theme used:
+            <code>
+              <pre>
+cssTheme: ODSCharts.ODSChartsCSSThemes.BOOSTED5,
+              </pre>
+            </code>
+          </p>
+          <p>
+            When using the external popover/tooltip feature, You can also specify the javascript used to display popover or tooltip.
+            The popover/tooltip renderer can be specify by the second argument of the <code>externalizePopover()</code> feature of the theme manager:
+            <code>
+              <pre>
+        themeManager.externalizePopover({},
+          ODSCharts.ODSChartsPopoverManagers.BOOSTED5
+        );
+          </pre>
+        </code>
+          </p>
+          <p>To choose between light or dark mode, you use the <code>cssSelector</code> option of <code>getThemeManager()</code>. 
+            It must give an html selector of an HTML element where the chart is displayed:
+            <code>
+              <pre>
+cssSelector: '#barLineGroup_chart'
+          </pre>
+        </code>
+          </p>
+          <p>To interact with a dynamic dark/light mode switch, you use the <code>manageThemeObserver()</code> feature of the theme manager:
+            <code>
+              <pre>
+themeManager.manageThemeObserver(myChart);
+          </pre>
+        </code></p>
+        <select class="form-select float-end" style="width: 300px;" aria-label="Default select example" onchange="document.querySelector('#t1-htmlId>div').setAttribute('data-bs-theme',this.value)">
+          
+          <option value="dark">Dark</option>
+          <option value="light" selected>Light</option>
+        </select>
+          <div id="t1-htmlId" >            
+            <div data-bs-theme="light">
+              <div class="chart_title overflow-hidden">
+                <h4 class="display-4 mx-3 mb-1 mt-3">Title</h4>
+                <h5 class="display-5 mx-3 mb-1 mt-0">Sub-Title</h5>
+              </div>
+
+              <div id="t1-barLineGroup_holder_with_legend" style="flex-grow: 1; flex-shrink: 1; display: flex; flex-direction: column;">
+                <div id="t1-barLineGroup_holder">
+                  <div id="t1-barLineGroup_chart" style="width: 100%; height: 50vh" class="position-relative"></div>
+                </div>
+                <div id="t1-barLineGroup_legend"></div>
+              </div>
+            </div>
+          </div>
+          <script>
+            addViewCode('t1-');
+          </script>
+        </div>
+      </div>
+      <script id="t1-codeId">
+      ///////////////////////////////////////////////////
+      // Used data
+      ///////////////////////////////////////////////////
+
+      // this is the data to be displayed
+      var dataOptions = {
+        "xAxis": {
+          "type": "category",
+          "data": [
+            "Jan",
+            "Feb",
+            "Mar",
+            "Apr",
+            "May",
+            "Jun"
+          ]
+        },
+        "yAxis": {},
+        "series": [
+          {
+            "data": [
+              10,
+              22,
+              28.8956454657,
+              23,
+              19,
+              15
+            ],
+            "type": "bar"
+          },
+          {
+            "data": [
+              28.8956454657,
+              23,
+              19,
+              15,
+              18,
+              12
+            ],
+            "type": "bar"
+          },
+          {
+            "data": [
+              12,
+              28.8956454657,
+              23,
+              15,
+              15,
+              18
+            ],
+            "type": "line"
+          }
+        ],
+        "legend": {
+          "data": [
+            "label 0",
+            "label 1",
+            "label 2"
+          ]
+        }
+      };
+
+        ///////////////////////////////////////////////////
+        // ODSCharts
+        ///////////////////////////////////////////////////
+        // Build the theme
+        var themeManager = ODSCharts.getThemeManager({
+          cssTheme: ODSCharts.ODSChartsCSSThemes.BOOSTED5,
+          cssSelector: '#t1-barLineGroup_chart'
+        });
+
+        // register this theme to echarts
+        echarts.registerTheme(themeManager.name , themeManager.theme);
+
+        // get the chart holder and initiate it with the generated theme
+        var div = document.getElementById('t1-barLineGroup_chart');
+        var myChart = echarts.init(div, themeManager.name, {
+          renderer: 'svg',
+        });
+
+        // Set the data to be displayed.
+        themeManager.setDataOptions(dataOptions);
+        // Register the externalization of the legend.
+        themeManager.externalizeLegends(myChart, '#t1-barLineGroup_legend');
+        // Manage window size changed
+        themeManager.manageChartResize(myChart, 't1-barLineGroup_chart');
+        // Automatically manage data-bs-theme attribute change. Only needed if you want the
+        // chart to automatically react to the global light or dark theme change
+        themeManager.manageThemeObserver(myChart);
+        // Register the externalization of the tooltip/popup
+        themeManager.externalizePopover({
+          },
+          ODSCharts.ODSChartsPopoverManagers.BOOSTED5
+        );
+        // Display the chart using the configured theme and data.
+        myChart.setOption(themeManager.getChartOptions());
+      </script>
+
+
+
+<div class="card w-100 mt-3">
+  <div class="card-body">
+    <h3 class="card-title">Global <span class="text-primary">Boosted</span> theme for <u>CSS</u> but <span class="text-primary">Apache Echarts</span> for <u>popover renderer</u></h5>
+    <p>
+      Let's change the previous use case to keep Boosted 5 as css theme but let's use Apache Echarts javascript to display popover/tooltip by changing the second argument of the <code>externalizePopover()</code> feature of the theme manager:
+      <code>
+        <pre>
+  themeManager.externalizePopover({},
+    ODSCharts.ODSChartsPopoverManagers.NONE
+  );
+    </pre>
+  </code>
+    </p>
+  <select class="form-select float-end" style="width: 300px;" aria-label="Default select example" onchange="document.querySelector('#t2-htmlId>div').setAttribute('data-bs-theme',this.value)">
+    
+    <option value="dark">Dark</option>
+    <option value="light" selected>Light</option>
+  </select>
+    <div id="t2-htmlId" >            
+      <div data-bs-theme="light">
+        <div class="chart_title overflow-hidden">
+          <h4 class="display-4 mx-3 mb-1 mt-3">Title</h4>
+          <h5 class="display-5 mx-3 mb-1 mt-0">Sub-Title</h5>
+        </div>
+
+        <div id="t2-barLineGroup_holder_with_legend" style="flex-grow: 1; flex-shrink: 1; display: flex; flex-direction: column;">
+          <div id="t2-barLineGroup_holder">
+            <div id="t2-barLineGroup_chart" style="width: 100%; height: 50vh" class="position-relative"></div>
+          </div>
+          <div id="t2-barLineGroup_legend"></div>
+        </div>
+      </div>
+    </div>
+    <script>
+      addViewCode('t2-');
+    </script>
+  </div>
+</div>
+<script id="t2-codeId">
+///////////////////////////////////////////////////
+// Used data
+///////////////////////////////////////////////////
+
+// this is the data to be displayed
+var dataOptions = {
+  "xAxis": {
+    "type": "category",
+    "data": [
+      "Jan",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun"
+    ]
+  },
+  "yAxis": {},
+  "series": [
+    {
+      "data": [
+        10,
+        22,
+        28.8956454657,
+        23,
+        19,
+        15
+      ],
+      "type": "bar"
+    },
+    {
+      "data": [
+        28.8956454657,
+        23,
+        19,
+        15,
+        18,
+        12
+      ],
+      "type": "bar"
+    },
+    {
+      "data": [
+        12,
+        28.8956454657,
+        23,
+        15,
+        15,
+        18
+      ],
+      "type": "line"
+    }
+  ],
+  "legend": {
+    "data": [
+      "label 0",
+      "label 1",
+      "label 2"
+    ]
+  }
+};
+
+  ///////////////////////////////////////////////////
+  // ODSCharts
+  ///////////////////////////////////////////////////
+  // Build the theme
+  var themeManager = ODSCharts.getThemeManager({
+    cssTheme: ODSCharts.ODSChartsCSSThemes.BOOSTED5,
+    cssSelector: '#t2-barLineGroup_chart'
+  });
+
+  // register this theme to echarts
+  echarts.registerTheme(themeManager.name , themeManager.theme);
+
+  // get the chart holder and initiate it with the generated theme
+  var div = document.getElementById('t2-barLineGroup_chart');
+  var myChart = echarts.init(div, themeManager.name, {
+    renderer: 'svg',
+  });
+
+  // Set the data to be displayed.
+  themeManager.setDataOptions(dataOptions);
+  // Register the externalization of the legend.
+  themeManager.externalizeLegends(myChart, '#t2-barLineGroup_legend');
+  // Manage window size changed
+  themeManager.manageChartResize(myChart, 't2-barLineGroup_chart');
+  // Automatically manage data-bs-theme attribute change. Only needed if you want the
+  // chart to automatically react to the global light or dark theme change
+  themeManager.manageThemeObserver(myChart);
+  // Register the externalization of the tooltip/popup
+  themeManager.externalizePopover({
+    },
+    ODSCharts.ODSChartsPopoverManagers.NONE
+  );
+  // Display the chart using the configured theme and data.
+  myChart.setOption(themeManager.getChartOptions());
+</script>
+
+
+
+
+<div class="card w-100 mt-3">
+  <div class="card-body">
+    <h3 class="card-title"><span class="text-primary">ODS Charts</span> embedded <u>CSS</u> theme and <span class="text-primary">Apache Echarts</span> <u>popover renderer</u></h5>
+    <p>
+      Som ODS Charts usage may be independant from Boosted. For that, ODS Charts has a minimal css embedded. 
+      To use it, change the  do so, the <code>cssTheme</code> option of <code>getThemeManager()</code> with:
+      <code>
+        <pre>
+cssTheme: ODSCharts.ODSChartsCSSThemes.NONE,
+        </pre>
+      </code>
+      <p>You still can use a dark/light theme mode by adding the <code>ods-charts-context</code> class and <code>data-bs-theme</code> attribute on the graph element holder:
+<code>
+        <pre>
+&lt;div class="ods-charts-context" data-bs-theme="light"&gt;
+    </pre>
+  </code>
+    </p>
+  <select class="form-select float-end" style="width: 300px;" aria-label="Default select example" onchange="document.querySelector('#t3-htmlId>div').setAttribute('data-bs-theme',this.value)">
+    
+    <option value="dark">Dark</option>
+    <option value="light" selected>Light</option>
+  </select>
+    <div id="t3-htmlId" >            
+      <div class="ods-charts-context" data-bs-theme="light">
+        <div class="chart_title overflow-hidden">
+          <h4 class="display-4 mx-3 mb-1 mt-3">Title</h4>
+          <h5 class="display-5 mx-3 mb-1 mt-0">Sub-Title</h5>
+        </div>
+
+        <div id="t3-barLineGroup_holder_with_legend" style="flex-grow: 1; flex-shrink: 1; display: flex; flex-direction: column;">
+          <div id="t3-barLineGroup_holder">
+            <div id="t3-barLineGroup_chart" style="width: 100%; height: 50vh" class="position-relative"></div>
+          </div>
+          <div id="t3-barLineGroup_legend"></div>
+        </div>
+      </div>
+    </div>
+    <script>
+      addViewCode('t3-');
+    </script>
+  </div>
+</div>
+<script id="t3-codeId">
+///////////////////////////////////////////////////
+// Used data
+///////////////////////////////////////////////////
+
+// this is the data to be displayed
+var dataOptions = {
+  "xAxis": {
+    "type": "category",
+    "data": [
+      "Jan",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun"
+    ]
+  },
+  "yAxis": {},
+  "series": [
+    {
+      "data": [
+        10,
+        22,
+        28.8956454657,
+        23,
+        19,
+        15
+      ],
+      "type": "bar"
+    },
+    {
+      "data": [
+        28.8956454657,
+        23,
+        19,
+        15,
+        18,
+        12
+      ],
+      "type": "bar"
+    },
+    {
+      "data": [
+        12,
+        28.8956454657,
+        23,
+        15,
+        15,
+        18
+      ],
+      "type": "line"
+    }
+  ],
+  "legend": {
+    "data": [
+      "label 0",
+      "label 1",
+      "label 2"
+    ]
+  }
+};
+
+  ///////////////////////////////////////////////////
+  // ODSCharts
+  ///////////////////////////////////////////////////
+  // Build the theme
+  var themeManager = ODSCharts.getThemeManager({
+    cssTheme: ODSCharts.ODSChartsCSSThemes.NONE,
+    cssSelector: '#t3-barLineGroup_chart'
+  });
+
+  // register this theme to echarts
+  echarts.registerTheme(themeManager.name , themeManager.theme);
+
+  // get the chart holder and initiate it with the generated theme
+  var div = document.getElementById('t3-barLineGroup_chart');
+  var myChart = echarts.init(div, themeManager.name, {
+    renderer: 'svg',
+  });
+
+  // Set the data to be displayed.
+  themeManager.setDataOptions(dataOptions);
+  // Register the externalization of the legend.
+  themeManager.externalizeLegends(myChart, '#t3-barLineGroup_legend');
+  // Manage window size changed
+  themeManager.manageChartResize(myChart, 't3-barLineGroup_chart');
+  // Automatically manage data-bs-theme attribute change. Only needed if you want the
+  // chart to automatically react to the global light or dark theme change
+  themeManager.manageThemeObserver(myChart);
+  // Register the externalization of the tooltip/popup
+  themeManager.externalizePopover({
+    },
+    ODSCharts.ODSChartsPopoverManagers.NONE
+  );
+  // Display the chart using the configured theme and data.
+  myChart.setOption(themeManager.getChartOptions());
+</script>
+
+
+    </div>
+
+    <footer class="footer navbar mt-5" data-bs-theme="dark">
+      <h2 class="visually-hidden">Sitemap & information</h2>
+      <div class="container-xxl footer-terms">
+        <ul class="navbar-nav gap-md-3">
+          <li class="fw-bold">© Orange 2024</li>
+          <li><a class="nav-link" href="javascript:tarteaucitron.userInterface.openPanel();">Cookies</a></li>
+          <li><a class="nav-link" href="https://github.com/Orange-OpenSource/ods-charts/blob/main/LICENSE" target="blank" rel="license noopener">License</a></li>
+        </ul>
+      </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/js/boosted.bundle.min.js" integrity="sha384-3RoJImQ+Yz4jAyP6xW29kJhqJOE3rdjuu9wkNycjCuDnGAtC/crm79mLcwj1w2o/" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/tarteaucitronjs@1.17.0/tarteaucitron.min.js" integrity="sha384-g6Xxn1zA15svldHyZ/Ow+wUUeRxHf/v7eOOO2sMafcnMPFD25n80Yz/3bbhJBSoN" crossorigin="anonymous"></script>
+    <script src="../assets/tarteaucitron-config.js"></script>
+  </body>
+</html>

--- a/docs/use_cases/theme.html
+++ b/docs/use_cases/theme.html
@@ -77,11 +77,10 @@
     <div class="container pt-3">
       <div class="card w-100">
         <div class="card-body">
-          <h3 class="card-title">Global <span class="text-primary">Boosted</span> theme for <u>CSS</u> and <u>popover renderer</u></h5>
+          <h3 class="card-title">Global <span class="text-primary">Boosted</span> theme for <u>CSS</u> and <u>popover renderer</u></h3>
           <p class="card-text">The most common use case should be using Boosted framework and its theme.</p>
           <p class="card-text">
-            To do so, the <code>getThemeManager()</code> has one 
-            <code>cssTheme</code> option that allows you to specify the css theme used:
+            To do so, the <code>getThemeManager()</code> has one <code>cssTheme</code> option that allows you to specify the css theme used:
             <code>
               <pre>
 cssTheme: ODSCharts.ODSChartsCSSThemes.BOOSTED5,
@@ -89,43 +88,46 @@ cssTheme: ODSCharts.ODSChartsCSSThemes.BOOSTED5,
             </code>
           </p>
           <p>
-            When using the external popover/tooltip feature, You can also specify the javascript used to display popover or tooltip.
-            The popover/tooltip renderer can be specify by the second argument of the <code>externalizePopover()</code> feature of the theme manager:
+            When using the external popover/tooltip feature, You can also specify the javascript used to display popover or tooltip. The popover/tooltip renderer can be specify by the second argument of the <code>externalizePopover()</code> feature of the theme manager:
             <code>
               <pre>
         themeManager.externalizePopover({},
           ODSCharts.ODSChartsPopoverManagers.BOOSTED5
         );
-          </pre>
-        </code>
+          </pre
+              >
+            </code>
           </p>
-          <p>To choose between light or dark mode, you use the <code>cssSelector</code> option of <code>getThemeManager()</code>. 
-            It must give an HTML selector of an HTML element where the chart is displayed:
+          <p>
+            To choose between light or dark mode, you use the <code>cssSelector</code> option of <code>getThemeManager()</code>. It must give an HTML selector of an HTML element where the chart is displayed:
             <code>
               <pre>
 cssSelector: '#barLineGroup_chart'
-          </pre>
-        </code>
+          </pre
+              >
+            </code>
           </p>
-          <p>To interact with a dynamic dark/light mode switch, you use the <code>manageThemeObserver()</code> feature of the theme manager:
+          <p>
+            To interact with a dynamic dark/light mode switch, you use the <code>manageThemeObserver()</code> feature of the theme manager:
             <code>
               <pre>
 themeManager.manageThemeObserver(myChart);
-          </pre>
-        </code></p>
-        <select class="form-select float-end" style="width: 300px;" aria-label="Default select example" onchange="document.querySelector('#t1-htmlId>div').setAttribute('data-bs-theme',this.value)">
-          
-          <option value="dark">Dark</option>
-          <option value="light" selected>Light</option>
-        </select>
-          <div id="t1-htmlId" >            
+          </pre
+              >
+            </code>
+          </p>
+          <select class="form-select float-end" style="width: 300px" aria-label="Default select example" onchange="document.querySelector('#t1-htmlId>div').setAttribute('data-bs-theme',this.value)">
+            <option value="dark">Dark</option>
+            <option value="light" selected>Light</option>
+          </select>
+          <div id="t1-htmlId">
             <div data-bs-theme="light">
               <div class="chart_title overflow-hidden">
                 <h4 class="display-4 mx-3 mb-1 mt-3">Title</h4>
                 <h5 class="display-5 mx-3 mb-1 mt-0">Sub-Title</h5>
               </div>
 
-              <div id="t1-barLineGroup_holder_with_legend" style="flex-grow: 1; flex-shrink: 1; display: flex; flex-direction: column;">
+              <div id="t1-barLineGroup_holder_with_legend" style="flex-grow: 1; flex-shrink: 1; display: flex; flex-direction: column">
                 <div id="t1-barLineGroup_holder">
                   <div id="t1-barLineGroup_chart" style="width: 100%; height: 50vh" class="position-relative"></div>
                 </div>
@@ -139,67 +141,35 @@ themeManager.manageThemeObserver(myChart);
         </div>
       </div>
       <script id="t1-codeId">
-      ///////////////////////////////////////////////////
-      // Used data
-      ///////////////////////////////////////////////////
+        ///////////////////////////////////////////////////
+        // Used data
+        ///////////////////////////////////////////////////
 
-      // this is the data to be displayed
-      var dataOptions = {
-        "xAxis": {
-          "type": "category",
-          "data": [
-            "Jan",
-            "Feb",
-            "Mar",
-            "Apr",
-            "May",
-            "Jun"
-          ]
-        },
-        "yAxis": {},
-        "series": [
-          {
-            "data": [
-              10,
-              22,
-              28.8956454657,
-              23,
-              19,
-              15
-            ],
-            "type": "bar"
+        // this is the data to be displayed
+        var dataOptions = {
+          xAxis: {
+            type: 'category',
+            data: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
           },
-          {
-            "data": [
-              28.8956454657,
-              23,
-              19,
-              15,
-              18,
-              12
-            ],
-            "type": "bar"
+          yAxis: {},
+          series: [
+            {
+              data: [10, 22, 28.8956454657, 23, 19, 15],
+              type: 'bar',
+            },
+            {
+              data: [28.8956454657, 23, 19, 15, 18, 12],
+              type: 'bar',
+            },
+            {
+              data: [12, 28.8956454657, 23, 15, 15, 18],
+              type: 'line',
+            },
+          ],
+          legend: {
+            data: ['label 0', 'label 1', 'label 2'],
           },
-          {
-            "data": [
-              12,
-              28.8956454657,
-              23,
-              15,
-              15,
-              18
-            ],
-            "type": "line"
-          }
-        ],
-        "legend": {
-          "data": [
-            "label 0",
-            "label 1",
-            "label 2"
-          ]
-        }
-      };
+        };
 
         ///////////////////////////////////////////////////
         // ODSCharts
@@ -207,11 +177,11 @@ themeManager.manageThemeObserver(myChart);
         // Build the theme
         var themeManager = ODSCharts.getThemeManager({
           cssTheme: ODSCharts.ODSChartsCSSThemes.BOOSTED5,
-          cssSelector: '#t1-barLineGroup_chart'
+          cssSelector: '#t1-barLineGroup_chart',
         });
 
         // register this theme to echarts
-        echarts.registerTheme(themeManager.name , themeManager.theme);
+        echarts.registerTheme(themeManager.name, themeManager.theme);
 
         // get the chart holder and initiate it with the generated theme
         var div = document.getElementById('t1-barLineGroup_chart');
@@ -229,299 +199,222 @@ themeManager.manageThemeObserver(myChart);
         // chart to automatically react to the global light or dark theme change
         themeManager.manageThemeObserver(myChart);
         // Register the externalization of the tooltip/popup
-        themeManager.externalizePopover({
-          },
-          ODSCharts.ODSChartsPopoverManagers.BOOSTED5
-        );
+        themeManager.externalizePopover({}, ODSCharts.ODSChartsPopoverManagers.BOOSTED5);
         // Display the chart using the configured theme and data.
         myChart.setOption(themeManager.getChartOptions());
       </script>
 
-
-
-<div class="card w-100 mt-3">
-  <div class="card-body">
-    <h3 class="card-title">Global <span class="text-primary">Boosted</span> theme for <u>CSS</u> but <span class="text-primary">Apache Echarts</span> for <u>popover renderer</u></h5>
-    <p>
-      Let's change the previous use case to keep Boosted 5 as CSS theme but let's use Apache Echarts javascript to display popover/tooltip by changing the second argument of the <code>externalizePopover()</code> feature of the theme manager:
-      <code>
-        <pre>
+      <div class="card w-100 mt-3">
+        <div class="card-body">
+          <h3 class="card-title">Global <span class="text-primary">Boosted</span> theme for <u>CSS</u> but <span class="text-primary">Apache Echarts</span> for <u>popover renderer</u></h3>
+          <p>
+            Let's change the previous use case to keep Boosted 5 as CSS theme but let's use Apache Echarts javascript to display popover/tooltip by changing the second argument of the <code>externalizePopover()</code> feature of the theme manager:
+            <code>
+              <pre>
   themeManager.externalizePopover({},
     ODSCharts.ODSChartsPopoverManagers.NONE
   );
-    </pre>
-  </code>
-    </p>
-  <select class="form-select float-end" style="width: 300px;" aria-label="Default select example" onchange="document.querySelector('#t2-htmlId>div').setAttribute('data-bs-theme',this.value)">
-    
-    <option value="dark">Dark</option>
-    <option value="light" selected>Light</option>
-  </select>
-    <div id="t2-htmlId" >            
-      <div data-bs-theme="light">
-        <div class="chart_title overflow-hidden">
-          <h4 class="display-4 mx-3 mb-1 mt-3">Title</h4>
-          <h5 class="display-5 mx-3 mb-1 mt-0">Sub-Title</h5>
-        </div>
+    </pre
+              >
+            </code>
+          </p>
+          <select class="form-select float-end" style="width: 300px" aria-label="Default select example" onchange="document.querySelector('#t2-htmlId>div').setAttribute('data-bs-theme',this.value)">
+            <option value="dark">Dark</option>
+            <option value="light" selected>Light</option>
+          </select>
+          <div id="t2-htmlId">
+            <div data-bs-theme="light">
+              <div class="chart_title overflow-hidden">
+                <h4 class="display-4 mx-3 mb-1 mt-3">Title</h4>
+                <h5 class="display-5 mx-3 mb-1 mt-0">Sub-Title</h5>
+              </div>
 
-        <div id="t2-barLineGroup_holder_with_legend" style="flex-grow: 1; flex-shrink: 1; display: flex; flex-direction: column;">
-          <div id="t2-barLineGroup_holder">
-            <div id="t2-barLineGroup_chart" style="width: 100%; height: 50vh" class="position-relative"></div>
+              <div id="t2-barLineGroup_holder_with_legend" style="flex-grow: 1; flex-shrink: 1; display: flex; flex-direction: column">
+                <div id="t2-barLineGroup_holder">
+                  <div id="t2-barLineGroup_chart" style="width: 100%; height: 50vh" class="position-relative"></div>
+                </div>
+                <div id="t2-barLineGroup_legend"></div>
+              </div>
+            </div>
           </div>
-          <div id="t2-barLineGroup_legend"></div>
+          <script>
+            addViewCode('t2-');
+          </script>
         </div>
       </div>
-    </div>
-    <script>
-      addViewCode('t2-');
-    </script>
-  </div>
-</div>
-<script id="t2-codeId">
-///////////////////////////////////////////////////
-// Used data
-///////////////////////////////////////////////////
+      <script id="t2-codeId">
+        ///////////////////////////////////////////////////
+        // Used data
+        ///////////////////////////////////////////////////
 
-// this is the data to be displayed
-var dataOptions = {
-  "xAxis": {
-    "type": "category",
-    "data": [
-      "Jan",
-      "Feb",
-      "Mar",
-      "Apr",
-      "May",
-      "Jun"
-    ]
-  },
-  "yAxis": {},
-  "series": [
-    {
-      "data": [
-        10,
-        22,
-        28.8956454657,
-        23,
-        19,
-        15
-      ],
-      "type": "bar"
-    },
-    {
-      "data": [
-        28.8956454657,
-        23,
-        19,
-        15,
-        18,
-        12
-      ],
-      "type": "bar"
-    },
-    {
-      "data": [
-        12,
-        28.8956454657,
-        23,
-        15,
-        15,
-        18
-      ],
-      "type": "line"
-    }
-  ],
-  "legend": {
-    "data": [
-      "label 0",
-      "label 1",
-      "label 2"
-    ]
-  }
-};
+        // this is the data to be displayed
+        var dataOptions = {
+          xAxis: {
+            type: 'category',
+            data: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+          },
+          yAxis: {},
+          series: [
+            {
+              data: [10, 22, 28.8956454657, 23, 19, 15],
+              type: 'bar',
+            },
+            {
+              data: [28.8956454657, 23, 19, 15, 18, 12],
+              type: 'bar',
+            },
+            {
+              data: [12, 28.8956454657, 23, 15, 15, 18],
+              type: 'line',
+            },
+          ],
+          legend: {
+            data: ['label 0', 'label 1', 'label 2'],
+          },
+        };
 
-  ///////////////////////////////////////////////////
-  // ODSCharts
-  ///////////////////////////////////////////////////
-  // Build the theme
-  var themeManager = ODSCharts.getThemeManager({
-    cssTheme: ODSCharts.ODSChartsCSSThemes.BOOSTED5,
-    cssSelector: '#t2-barLineGroup_chart'
-  });
+        ///////////////////////////////////////////////////
+        // ODSCharts
+        ///////////////////////////////////////////////////
+        // Build the theme
+        var themeManager = ODSCharts.getThemeManager({
+          cssTheme: ODSCharts.ODSChartsCSSThemes.BOOSTED5,
+          cssSelector: '#t2-barLineGroup_chart',
+        });
 
-  // register this theme to echarts
-  echarts.registerTheme(themeManager.name , themeManager.theme);
+        // register this theme to echarts
+        echarts.registerTheme(themeManager.name, themeManager.theme);
 
-  // get the chart holder and initiate it with the generated theme
-  var div = document.getElementById('t2-barLineGroup_chart');
-  var myChart = echarts.init(div, themeManager.name, {
-    renderer: 'svg',
-  });
+        // get the chart holder and initiate it with the generated theme
+        var div = document.getElementById('t2-barLineGroup_chart');
+        var myChart = echarts.init(div, themeManager.name, {
+          renderer: 'svg',
+        });
 
-  // Set the data to be displayed.
-  themeManager.setDataOptions(dataOptions);
-  // Register the externalization of the legend.
-  themeManager.externalizeLegends(myChart, '#t2-barLineGroup_legend');
-  // Manage window size changed
-  themeManager.manageChartResize(myChart, 't2-barLineGroup_chart');
-  // Automatically manage data-bs-theme attribute change. Only needed if you want the
-  // chart to automatically react to the global light or dark theme change
-  themeManager.manageThemeObserver(myChart);
-  // Register the externalization of the tooltip/popup
-  themeManager.externalizePopover({
-    },
-    ODSCharts.ODSChartsPopoverManagers.NONE
-  );
-  // Display the chart using the configured theme and data.
-  myChart.setOption(themeManager.getChartOptions());
-</script>
+        // Set the data to be displayed.
+        themeManager.setDataOptions(dataOptions);
+        // Register the externalization of the legend.
+        themeManager.externalizeLegends(myChart, '#t2-barLineGroup_legend');
+        // Manage window size changed
+        themeManager.manageChartResize(myChart, 't2-barLineGroup_chart');
+        // Automatically manage data-bs-theme attribute change. Only needed if you want the
+        // chart to automatically react to the global light or dark theme change
+        themeManager.manageThemeObserver(myChart);
+        // Register the externalization of the tooltip/popup
+        themeManager.externalizePopover({}, ODSCharts.ODSChartsPopoverManagers.NONE);
+        // Display the chart using the configured theme and data.
+        myChart.setOption(themeManager.getChartOptions());
+      </script>
 
-
-
-
-<div class="card w-100 mt-3">
-  <div class="card-body">
-    <h3 class="card-title"><span class="text-primary">ODS Charts</span> embedded <u>CSS</u> theme and <span class="text-primary">Apache Echarts</span> <u>popover renderer</u></h5>
-    <p>
-      Some ODS Charts usage may be independent from Boosted. For that, ODS Charts has a minimal CSS embedded. 
-      To use it, change the <code>cssTheme</code> option of <code>getThemeManager()</code> with:
-      <code>
-        <pre>
+      <div class="card w-100 mt-3">
+        <div class="card-body">
+          <h3 class="card-title"><span class="text-primary">ODS Charts</span> embedded <u>CSS</u> theme and <span class="text-primary">Apache Echarts</span> <u>popover renderer</u></h3>
+          <p>
+            Some ODS Charts usage may be independent from Boosted. For that, ODS Charts has a minimal CSS embedded. To use it, change the <code>cssTheme</code> option of <code>getThemeManager()</code> with:
+            <code>
+              <pre>
 cssTheme: ODSCharts.ODSChartsCSSThemes.NONE,
-        </pre>
-      </code>
-      <p>You still can use a dark/light theme mode by adding the <code>ods-charts-context</code> class and <code>data-bs-theme</code> attribute on the graph element holder:
-<code>
-        <pre>
-&lt;div class="ods-charts-context" data-bs-theme="light"&gt;
-    </pre>
-  </code>
-    </p>
-  <select class="form-select float-end" style="width: 300px;" aria-label="Default select example" onchange="document.querySelector('#t3-htmlId>div').setAttribute('data-bs-theme',this.value)">
-    
-    <option value="dark">Dark</option>
-    <option value="light" selected>Light</option>
-  </select>
-    <div id="t3-htmlId" >            
-      <div class="ods-charts-context" data-bs-theme="light">
-        <div class="chart_title overflow-hidden">
-          <h4 class="display-4 mx-3 mb-1 mt-3">Title</h4>
-          <h5 class="display-5 mx-3 mb-1 mt-0">Sub-Title</h5>
-        </div>
+        </pre
+              >
+            </code>
+          </p>
 
-        <div id="t3-barLineGroup_holder_with_legend" style="flex-grow: 1; flex-shrink: 1; display: flex; flex-direction: column;">
-          <div id="t3-barLineGroup_holder">
-            <div id="t3-barLineGroup_chart" style="width: 100%; height: 50vh" class="position-relative"></div>
+          <p>
+            You still can use a dark/light theme mode by adding the <code>ods-charts-context</code> class and <code>data-bs-theme</code> attribute on the graph element holder:
+            <code>
+              <pre>
+&lt;div class="ods-charts-context" data-bs-theme="light"&gt;
+    </pre
+              >
+            </code>
+          </p>
+          <select class="form-select float-end" style="width: 300px" aria-label="Default select example" onchange="document.querySelector('#t3-htmlId>div').setAttribute('data-bs-theme',this.value)">
+            <option value="dark">Dark</option>
+            <option value="light" selected>Light</option>
+          </select>
+          <div id="t3-htmlId">
+            <div class="ods-charts-context" data-bs-theme="light">
+              <div class="chart_title overflow-hidden">
+                <h4 class="display-4 mx-3 mb-1 mt-3">Title</h4>
+                <h5 class="display-5 mx-3 mb-1 mt-0">Sub-Title</h5>
+              </div>
+
+              <div id="t3-barLineGroup_holder_with_legend" style="flex-grow: 1; flex-shrink: 1; display: flex; flex-direction: column">
+                <div id="t3-barLineGroup_holder">
+                  <div id="t3-barLineGroup_chart" style="width: 100%; height: 50vh" class="position-relative"></div>
+                </div>
+                <div id="t3-barLineGroup_legend"></div>
+              </div>
+            </div>
           </div>
-          <div id="t3-barLineGroup_legend"></div>
+          <script>
+            addViewCode('t3-');
+          </script>
         </div>
       </div>
-    </div>
-    <script>
-      addViewCode('t3-');
-    </script>
-  </div>
-</div>
-<script id="t3-codeId">
-///////////////////////////////////////////////////
-// Used data
-///////////////////////////////////////////////////
+      <script id="t3-codeId">
+        ///////////////////////////////////////////////////
+        // Used data
+        ///////////////////////////////////////////////////
 
-// this is the data to be displayed
-var dataOptions = {
-  "xAxis": {
-    "type": "category",
-    "data": [
-      "Jan",
-      "Feb",
-      "Mar",
-      "Apr",
-      "May",
-      "Jun"
-    ]
-  },
-  "yAxis": {},
-  "series": [
-    {
-      "data": [
-        10,
-        22,
-        28.8956454657,
-        23,
-        19,
-        15
-      ],
-      "type": "bar"
-    },
-    {
-      "data": [
-        28.8956454657,
-        23,
-        19,
-        15,
-        18,
-        12
-      ],
-      "type": "bar"
-    },
-    {
-      "data": [
-        12,
-        28.8956454657,
-        23,
-        15,
-        15,
-        18
-      ],
-      "type": "line"
-    }
-  ],
-  "legend": {
-    "data": [
-      "label 0",
-      "label 1",
-      "label 2"
-    ]
-  }
-};
+        // this is the data to be displayed
+        var dataOptions = {
+          xAxis: {
+            type: 'category',
+            data: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+          },
+          yAxis: {},
+          series: [
+            {
+              data: [10, 22, 28.8956454657, 23, 19, 15],
+              type: 'bar',
+            },
+            {
+              data: [28.8956454657, 23, 19, 15, 18, 12],
+              type: 'bar',
+            },
+            {
+              data: [12, 28.8956454657, 23, 15, 15, 18],
+              type: 'line',
+            },
+          ],
+          legend: {
+            data: ['label 0', 'label 1', 'label 2'],
+          },
+        };
 
-  ///////////////////////////////////////////////////
-  // ODSCharts
-  ///////////////////////////////////////////////////
-  // Build the theme
-  var themeManager = ODSCharts.getThemeManager({
-    cssTheme: ODSCharts.ODSChartsCSSThemes.NONE,
-    cssSelector: '#t3-barLineGroup_chart'
-  });
+        ///////////////////////////////////////////////////
+        // ODSCharts
+        ///////////////////////////////////////////////////
+        // Build the theme
+        var themeManager = ODSCharts.getThemeManager({
+          cssTheme: ODSCharts.ODSChartsCSSThemes.NONE,
+          cssSelector: '#t3-barLineGroup_chart',
+        });
 
-  // register this theme to echarts
-  echarts.registerTheme(themeManager.name , themeManager.theme);
+        // register this theme to echarts
+        echarts.registerTheme(themeManager.name, themeManager.theme);
 
-  // get the chart holder and initiate it with the generated theme
-  var div = document.getElementById('t3-barLineGroup_chart');
-  var myChart = echarts.init(div, themeManager.name, {
-    renderer: 'svg',
-  });
+        // get the chart holder and initiate it with the generated theme
+        var div = document.getElementById('t3-barLineGroup_chart');
+        var myChart = echarts.init(div, themeManager.name, {
+          renderer: 'svg',
+        });
 
-  // Set the data to be displayed.
-  themeManager.setDataOptions(dataOptions);
-  // Register the externalization of the legend.
-  themeManager.externalizeLegends(myChart, '#t3-barLineGroup_legend');
-  // Manage window size changed
-  themeManager.manageChartResize(myChart, 't3-barLineGroup_chart');
-  // Automatically manage data-bs-theme attribute change. Only needed if you want the
-  // chart to automatically react to the global light or dark theme change
-  themeManager.manageThemeObserver(myChart);
-  // Register the externalization of the tooltip/popup
-  themeManager.externalizePopover({
-    },
-    ODSCharts.ODSChartsPopoverManagers.NONE
-  );
-  // Display the chart using the configured theme and data.
-  myChart.setOption(themeManager.getChartOptions());
-</script>
-
-
+        // Set the data to be displayed.
+        themeManager.setDataOptions(dataOptions);
+        // Register the externalization of the legend.
+        themeManager.externalizeLegends(myChart, '#t3-barLineGroup_legend');
+        // Manage window size changed
+        themeManager.manageChartResize(myChart, 't3-barLineGroup_chart');
+        // Automatically manage data-bs-theme attribute change. Only needed if you want the
+        // chart to automatically react to the global light or dark theme change
+        themeManager.manageThemeObserver(myChart);
+        // Register the externalization of the tooltip/popup
+        themeManager.externalizePopover({}, ODSCharts.ODSChartsPopoverManagers.NONE);
+        // Display the chart using the configured theme and data.
+        myChart.setOption(themeManager.getChartOptions());
+      </script>
     </div>
 
     <footer class="footer navbar mt-5" data-bs-theme="dark">

--- a/docs/use_cases/time-slider.html
+++ b/docs/use_cases/time-slider.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Examples - Specific use cases - Time slider axis</title>
+    <title>Time slider axis - Specific use cases - ODS Charts</title>
 
     <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/orange-helvetica.min.css" rel="stylesheet" integrity="sha384-A0Qk1uKfS1i83/YuU13i2nx5pk79PkIfNFOVzTcjCMPGKIDj9Lqx9lJmV7cdBVQZ" crossorigin="anonymous" />
     <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/boosted.min.css" rel="stylesheet" integrity="sha384-laZ3JUZ5Ln2YqhfBvadDpNyBo7w5qmWaRnnXuRwNhJeTEFuSdGbzl4ZGHAEnTozR" crossorigin="anonymous" />

--- a/docs/use_cases/tooltip.html
+++ b/docs/use_cases/tooltip.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Examples - Specific use cases - Tooltip</title>
+    <title>Tooltip - Specific use cases - ODS Charts</title>
 
     <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/orange-helvetica.min.css" rel="stylesheet" integrity="sha384-A0Qk1uKfS1i83/YuU13i2nx5pk79PkIfNFOVzTcjCMPGKIDj9Lqx9lJmV7cdBVQZ" crossorigin="anonymous" />
     <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/boosted.min.css" rel="stylesheet" integrity="sha384-laZ3JUZ5Ln2YqhfBvadDpNyBo7w5qmWaRnnXuRwNhJeTEFuSdGbzl4ZGHAEnTozR" crossorigin="anonymous" />

--- a/docs/use_cases/two-colors-serie.html
+++ b/docs/use_cases/two-colors-serie.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Examples - Specific use cases - Two colors for one series</title>
+    <title>Two colors for one series - Specific use cases - ODS Charts</title>
 
     <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/orange-helvetica.min.css" rel="stylesheet" integrity="sha384-A0Qk1uKfS1i83/YuU13i2nx5pk79PkIfNFOVzTcjCMPGKIDj9Lqx9lJmV7cdBVQZ" crossorigin="anonymous" />
     <link href="https://cdn.jsdelivr.net/npm/boosted@5.3.3/dist/css/boosted.min.css" rel="stylesheet" integrity="sha384-laZ3JUZ5Ln2YqhfBvadDpNyBo7w5qmWaRnnXuRwNhJeTEFuSdGbzl4ZGHAEnTozR" crossorigin="anonymous" />


### PR DESCRIPTION
### Related issues


### Description

Provides a new use case page on ODS Charts options to choose the theme provider.

### Motivation & Context

Options may be complex between options for:
- CSS theme , 
- popover renderer 
- dark/light mode

### Types of change

- New feature

### Test checklist

Please check that the following tests projects are still working:

- [ ] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [ ] `test\angular-ng-boosted`
- [ ] `test/angular-echarts`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`
- [ ] `test/examples/timeseries-chart`
