### PR TITLE
feat(colors): Add OUDS color palettes.

### DIFF
--- a/docs/colors/index.js
+++ b/docs/colors/index.js
@@ -38,7 +38,7 @@ function displayColorSet(containerId, colorSet, colorSetLabel) {
     `;
     })
     .join('')}
-   
+
     `;
 
   if (colorSetLabel) {
@@ -62,6 +62,15 @@ function displayAllColorSets(divId) {
     ['SEQUENTIAL_PINK', 'Pink'],
     ['SEQUENTIAL_PURPLE', 'Purple'],
     ['SEQUENTIAL_YELLOW', 'Yellow'],
+    ['OUDS_SEQUENTIAL_BLUE', '[OUDS] Blue'],
+    ['OUDS_SEQUENTIAL_GREEN', '[OUDS] Green'],
+    ['OUDS_SEQUENTIAL_PINK', '[OUDS] Pink'],
+    ['OUDS_SEQUENTIAL_PURPLE', '[OUDS] Purple'],
+    ['OUDS_SEQUENTIAL_YELLOW', '[OUDS] Yellow'],
+    ['OUDS_CATEGORICAL', '[OUDS] Categorical'],
+    ['OUDS_FUNCTIONAL', '[OUDS] Functional'],
+    ['OUDS_HIGHLIGHT', '[OUDS] Highlight'],
+    ['OUDS_SINGLE', '[OUDS] Single'],
   ];
   document.getElementById(divId).innerHTML = sets
     .map(
@@ -75,12 +84,11 @@ function displayAllColorSets(divId) {
         </div>
       </div>
     </div>
-  
   `
     )
     .join('');
   sets.forEach((element) => {
-    displayColorSet(divId, element[0], element[1]);
+    displayColorSet(divId, element[0], `${element[1]}${element[1].startsWith('[OUDS]') ? ' (Experimental)' : ''}`);
   });
 }
 

--- a/docs/examples/index.js
+++ b/docs/examples/index.js
@@ -109,6 +109,15 @@ function generateConfigurator(id) {
                 <option value="${ODSCharts.ODSChartsColorsSet.SEQUENTIAL_PINK}">Pink (6)</option>
                 <option value="${ODSCharts.ODSChartsColorsSet.SEQUENTIAL_PURPLE}">Purple (6)</option>
                 <option value="${ODSCharts.ODSChartsColorsSet.SEQUENTIAL_YELLOW}">Yellow (6)</option>
+                <option value="${ODSCharts.ODSChartsColorsSet.OUDS_SEQUENTIAL_BLUE}">[OUDS] Blue (9)</option>
+                <option value="${ODSCharts.ODSChartsColorsSet.OUDS_SEQUENTIAL_GREEN}">[OUDS] Green (9)</option>
+                <option value="${ODSCharts.ODSChartsColorsSet.OUDS_SEQUENTIAL_PINK}">[OUDS] Pink (9)</option>
+                <option value="${ODSCharts.ODSChartsColorsSet.OUDS_SEQUENTIAL_PURPLE}">[OUDS] Purple (9)</option>
+                <option value="${ODSCharts.ODSChartsColorsSet.OUDS_SEQUENTIAL_YELLOW}">[OUDS] Yellow (9)</option>
+                <option value="${ODSCharts.ODSChartsColorsSet.OUDS_CATEGORICAL}">[OUDS] Categorical (10)</option>
+                <option value="${ODSCharts.ODSChartsColorsSet.OUDS_FUNCTIONAL}">[OUDS] Functional (3)</option>
+                <option value="${ODSCharts.ODSChartsColorsSet.OUDS_HIGHLIGHT}">[OUDS] Highlight (2)</option>
+                <option value="${ODSCharts.ODSChartsColorsSet.OUDS_SINGLE}">[OUDS] Single (6)</option>
               </select>
             </div>
 
@@ -627,7 +636,7 @@ async function changeTheme(id) {
     id,
     option,
     document.querySelector(`#accordion_${id} #darkModeInput`).value,
-    11 === document.querySelector(`#accordion_${id} #colorSetInput`).selectedIndex
+    20 === document.querySelector(`#accordion_${id} #colorSetInput`).selectedIndex
       ? JSON.parse(document.querySelector(`#accordion_${id} #colorSetInput`).value)
       : document.querySelector(`#accordion_${id} #colorSetInput`).value,
     document.querySelector(`#accordion_${id} #lineStyleInput`).value,
@@ -643,7 +652,7 @@ async function changeTheme(id) {
     true
   );
   if (document.querySelector('#view_custom_color_' + id)) {
-    if (11 === document.querySelector(`#accordion_${id} #colorSetInput`).selectedIndex) {
+    if (20 === document.querySelector(`#accordion_${id} #colorSetInput`).selectedIndex) {
       document.querySelector('#view_custom_color_' + id).classList.remove('d-none');
     } else {
       document.querySelector('#view_custom_color_' + id).classList.add('d-none');

--- a/src/theme/colors/_ouds-colors-css-variables.ts
+++ b/src/theme/colors/_ouds-colors-css-variables.ts
@@ -1,0 +1,144 @@
+//
+// Software Name: Orange Design System Charts
+// SPDX-FileCopyrightText: Copyright (c) 2023 - 2025 Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license.
+//
+
+export const ODS_CHARTS_CONTEXT = `
+.ods-charts-context, [data-bs-theme=light] .ods-charts-context, .ods-charts-context[data-bs-theme=light] {
+  color-scheme: light;
+  --ouds-charts-color-border: #ffffff;
+  --ouds-charts-color-border-contrast: #ffffff;
+  --ouds-charts-color-categorical-tier-1: #5b2f98;
+  --ouds-charts-color-categorical-tier-10: #009bf0;
+  --ouds-charts-color-categorical-tier-2: #3ba06e;
+  --ouds-charts-color-categorical-tier-3: #b20077;
+  --ouds-charts-color-categorical-tier-4: #a38200;
+  --ouds-charts-color-categorical-tier-5: #007abd;
+  --ouds-charts-color-categorical-tier-6: #8d60cd;
+  --ouds-charts-color-categorical-tier-7: #2e7b54;
+  --ouds-charts-color-categorical-tier-8: #e50099;
+  --ouds-charts-color-categorical-tier-9: #665100;
+  --ouds-charts-color-functional-info: #009bf0;
+  --ouds-charts-color-functional-negative: #db0002;
+  --ouds-charts-color-functional-positive: #17a02f;
+  --ouds-charts-color-functional-warning: #a38200;
+  --ouds-charts-color-gridlines: #cccccc;
+  --ouds-charts-color-highlight: #f15e00;
+  --ouds-charts-color-neutral: #8f8f8f;
+  --ouds-charts-color-sequential-accent-1-tint-100: #d2ecf9;
+  --ouds-charts-color-sequential-accent-1-tint-200: #a5daf3;
+  --ouds-charts-color-sequential-accent-1-tint-300: #79c7ec;
+  --ouds-charts-color-sequential-accent-1-tint-400: #4ab4e6;
+  --ouds-charts-color-sequential-accent-1-tint-500: #1fa2e0;
+  --ouds-charts-color-sequential-accent-1-tint-600: #1982b3;
+  --ouds-charts-color-sequential-accent-1-tint-700: #136186;
+  --ouds-charts-color-sequential-accent-1-tint-800: #0c415a;
+  --ouds-charts-color-sequential-accent-1-tint-900: #06202d;
+  --ouds-charts-color-sequential-accent-2-tint-100: #e5f5ed;
+  --ouds-charts-color-sequential-accent-2-tint-200: #c0e8d4;
+  --ouds-charts-color-sequential-accent-2-tint-300: #9bdaba;
+  --ouds-charts-color-sequential-accent-2-tint-400: #75cca1;
+  --ouds-charts-color-sequential-accent-2-tint-500: #50be87;
+  --ouds-charts-color-sequential-accent-2-tint-600: #3ba06e;
+  --ouds-charts-color-sequential-accent-2-tint-700: #2e7b54;
+  --ouds-charts-color-sequential-accent-2-tint-800: #20563b;
+  --ouds-charts-color-sequential-accent-2-tint-900: #123021;
+  --ouds-charts-color-sequential-accent-3-tint-100: #ffe5f6;
+  --ouds-charts-color-sequential-accent-3-tint-200: #ffb4e6;
+  --ouds-charts-color-sequential-accent-3-tint-300: #ff80d4;
+  --ouds-charts-color-sequential-accent-3-tint-400: #ff4dc3;
+  --ouds-charts-color-sequential-accent-3-tint-500: #ff1ab2;
+  --ouds-charts-color-sequential-accent-3-tint-600: #e50099;
+  --ouds-charts-color-sequential-accent-3-tint-700: #b20077;
+  --ouds-charts-color-sequential-accent-3-tint-800: #800055;
+  --ouds-charts-color-sequential-accent-3-tint-900: #4d0033;
+  --ouds-charts-color-sequential-accent-4-tint-100: #f1ecf9;
+  --ouds-charts-color-sequential-accent-4-tint-200: #e0d4f2;
+  --ouds-charts-color-sequential-accent-4-tint-300: #c5ade6;
+  --ouds-charts-color-sequential-accent-4-tint-400: #a885d8;
+  --ouds-charts-color-sequential-accent-4-tint-500: #8d60cd;
+  --ouds-charts-color-sequential-accent-4-tint-600: #5b2f98;
+  --ouds-charts-color-sequential-accent-4-tint-700: #432371;
+  --ouds-charts-color-sequential-accent-4-tint-800: #2c174a;
+  --ouds-charts-color-sequential-accent-4-tint-900: #150b23;
+  --ouds-charts-color-sequential-accent-5-tint-100: #fff0cc;
+  --ouds-charts-color-sequential-accent-5-tint-200: #ffe199;
+  --ouds-charts-color-sequential-accent-5-tint-300: #ffd266;
+  --ouds-charts-color-sequential-accent-5-tint-400: #ffc333;
+  --ouds-charts-color-sequential-accent-5-tint-500: #ffb400;
+  --ouds-charts-color-sequential-accent-5-tint-600: #cc9000;
+  --ouds-charts-color-sequential-accent-5-tint-700: #996c00;
+  --ouds-charts-color-sequential-accent-5-tint-800: #664800;
+  --ouds-charts-color-sequential-accent-5-tint-900: #332400;
+}
+
+[data-bs-theme=dark] .ods-charts-context, .ods-charts-context[data-bs-theme=dark] {
+  color-scheme: dark;
+  --ouds-charts-color-border: #141414;
+  --ouds-charts-color-border-contrast: #000000;
+  --ouds-charts-color-categorical-tier-1: #a885d8;
+  --ouds-charts-color-categorical-tier-10: #1fa2e0;
+  --ouds-charts-color-categorical-tier-2: #50be87;
+  --ouds-charts-color-categorical-tier-3: #ff80d4;
+  --ouds-charts-color-categorical-tier-4: #cc9000;
+  --ouds-charts-color-categorical-tier-5: #79c7ec;
+  --ouds-charts-color-categorical-tier-6: #8d60cd;
+  --ouds-charts-color-categorical-tier-7: #9bdaba;
+  --ouds-charts-color-categorical-tier-8: #ff4dc3;
+  --ouds-charts-color-categorical-tier-9: #ffd266;
+  --ouds-charts-color-functional-info: #26b2ff;
+  --ouds-charts-color-functional-negative: #ff4d4e;
+  --ouds-charts-color-functional-positive: #1ecd3c;
+  --ouds-charts-color-functional-warning: #ffd000;
+  --ouds-charts-color-gridlines: #666666;
+  --ouds-charts-color-highlight: #ff7900;
+  --ouds-charts-color-neutral: #858585;
+  --ouds-charts-color-sequential-accent-1-tint-100: #06202d;
+  --ouds-charts-color-sequential-accent-1-tint-200: #0c415a;
+  --ouds-charts-color-sequential-accent-1-tint-300: #136186;
+  --ouds-charts-color-sequential-accent-1-tint-400: #1982b3;
+  --ouds-charts-color-sequential-accent-1-tint-500: #1fa2e0;
+  --ouds-charts-color-sequential-accent-1-tint-600: #4ab4e6;
+  --ouds-charts-color-sequential-accent-1-tint-700: #79c7ec;
+  --ouds-charts-color-sequential-accent-1-tint-800: #a5daf3;
+  --ouds-charts-color-sequential-accent-1-tint-900: #d2ecf9;
+  --ouds-charts-color-sequential-accent-2-tint-100: #123021;
+  --ouds-charts-color-sequential-accent-2-tint-200: #20563b;
+  --ouds-charts-color-sequential-accent-2-tint-300: #2e7b54;
+  --ouds-charts-color-sequential-accent-2-tint-400: #3ba06e;
+  --ouds-charts-color-sequential-accent-2-tint-500: #50be87;
+  --ouds-charts-color-sequential-accent-2-tint-600: #75cca1;
+  --ouds-charts-color-sequential-accent-2-tint-700: #9bdaba;
+  --ouds-charts-color-sequential-accent-2-tint-800: #c0e8d4;
+  --ouds-charts-color-sequential-accent-2-tint-900: #e5f5ed;
+  --ouds-charts-color-sequential-accent-3-tint-100: #4d0033;
+  --ouds-charts-color-sequential-accent-3-tint-200: #800055;
+  --ouds-charts-color-sequential-accent-3-tint-300: #b20077;
+  --ouds-charts-color-sequential-accent-3-tint-400: #e50099;
+  --ouds-charts-color-sequential-accent-3-tint-500: #ff1ab2;
+  --ouds-charts-color-sequential-accent-3-tint-600: #ff4dc3;
+  --ouds-charts-color-sequential-accent-3-tint-700: #ff80d4;
+  --ouds-charts-color-sequential-accent-3-tint-800: #ffb4e6;
+  --ouds-charts-color-sequential-accent-3-tint-900: #ffe5f6;
+  --ouds-charts-color-sequential-accent-4-tint-100: #150b23;
+  --ouds-charts-color-sequential-accent-4-tint-200: #2c174a;
+  --ouds-charts-color-sequential-accent-4-tint-300: #432371;
+  --ouds-charts-color-sequential-accent-4-tint-400: #5b2f98;
+  --ouds-charts-color-sequential-accent-4-tint-500: #8d60cd;
+  --ouds-charts-color-sequential-accent-4-tint-600: #a885d8;
+  --ouds-charts-color-sequential-accent-4-tint-700: #c5ade6;
+  --ouds-charts-color-sequential-accent-4-tint-800: #e0d4f2;
+  --ouds-charts-color-sequential-accent-4-tint-900: #f1ecf9;
+  --ouds-charts-color-sequential-accent-5-tint-100: #332400;
+  --ouds-charts-color-sequential-accent-5-tint-200: #664800;
+  --ouds-charts-color-sequential-accent-5-tint-300: #996c00;
+  --ouds-charts-color-sequential-accent-5-tint-400: #cc9000;
+  --ouds-charts-color-sequential-accent-5-tint-500: #ffb400;
+  --ouds-charts-color-sequential-accent-5-tint-600: #ffc333;
+  --ouds-charts-color-sequential-accent-5-tint-700: #ffd266;
+  --ouds-charts-color-sequential-accent-5-tint-800: #ffe199;
+  --ouds-charts-color-sequential-accent-5-tint-900: #fff0cc;
+}`;

--- a/src/theme/colors/colors-css-variables.ts
+++ b/src/theme/colors/colors-css-variables.ts
@@ -7,6 +7,7 @@
 //
 
 import { ODSChartsCSSThemesNames } from '../css-themes/css-themes';
+import { ODS_CHARTS_CONTEXT } from './_ouds-colors-css-variables';
 
 /**
  * Added for None or Boosted 4 themes
@@ -312,16 +313,20 @@ export const ODS_CHARTS_CSS_VARIABLES: { [theme in ODSChartsCSSThemesNames]: str
   BOOSTED4: `
   ${BOOSTED5_VARIABLE}
   ${NON_BOOSTED5_VARIABLE}
+  ${ODS_CHARTS_CONTEXT}
   `,
   BOOSTED5: `
   ${NON_BOOSTED5_VARIABLE}
+  ${ODS_CHARTS_CONTEXT}
   `,
   CUSTOM: `
   ${BOOSTED5_VARIABLE}
   ${NON_BOOSTED5_VARIABLE}
+  ${ODS_CHARTS_CONTEXT}
   `,
   NONE: `
   ${BOOSTED5_VARIABLE}
   ${NON_BOOSTED5_VARIABLE}
+  ${ODS_CHARTS_CONTEXT}
   `,
 };

--- a/src/theme/default/OUDS.colors.blue.ts
+++ b/src/theme/default/OUDS.colors.blue.ts
@@ -1,0 +1,21 @@
+//
+// Software Name: Orange Design System Charts
+// SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license.
+//
+
+export const DEFAULT_OUDS_COLORS_BLUE = {
+  color: [
+    'var(--ouds-charts-color-sequential-accent-1-tint-100)',
+    'var(--ouds-charts-color-sequential-accent-1-tint-200)',
+    'var(--ouds-charts-color-sequential-accent-1-tint-300)',
+    'var(--ouds-charts-color-sequential-accent-1-tint-400)',
+    'var(--ouds-charts-color-sequential-accent-1-tint-500)',
+    'var(--ouds-charts-color-sequential-accent-1-tint-600)',
+    'var(--ouds-charts-color-sequential-accent-1-tint-700)',
+    'var(--ouds-charts-color-sequential-accent-1-tint-800)',
+    'var(--ouds-charts-color-sequential-accent-1-tint-900)',
+  ],
+};

--- a/src/theme/default/OUDS.colors.categorical.ts
+++ b/src/theme/default/OUDS.colors.categorical.ts
@@ -1,0 +1,22 @@
+//
+// Software Name: Orange Design System Charts
+// SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license.
+//
+
+export const DEFAULT_OUDS_COLORS_CATEGORICAL = {
+  color: [
+    'var(--ouds-charts-color-categorical-tier-1)',
+    'var(--ouds-charts-color-categorical-tier-2)',
+    'var(--ouds-charts-color-categorical-tier-3)',
+    'var(--ouds-charts-color-categorical-tier-4)',
+    'var(--ouds-charts-color-categorical-tier-5)',
+    'var(--ouds-charts-color-categorical-tier-6)',
+    'var(--ouds-charts-color-categorical-tier-7)',
+    'var(--ouds-charts-color-categorical-tier-8)',
+    'var(--ouds-charts-color-categorical-tier-9)',
+    'var(--ouds-charts-color-categorical-tier-10)',
+  ],
+};

--- a/src/theme/default/OUDS.colors.functional.ts
+++ b/src/theme/default/OUDS.colors.functional.ts
@@ -1,0 +1,11 @@
+//
+// Software Name: Orange Design System Charts
+// SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license.
+//
+
+export const DEFAULT_OUDS_COLORS_FUNCTIONAL = {
+  color: ['var(--ouds-charts-color-functional-positive)', 'var(--ouds-charts-color-functional-warning)', 'var(--ouds-charts-color-functional-negative)'],
+};

--- a/src/theme/default/OUDS.colors.green.ts
+++ b/src/theme/default/OUDS.colors.green.ts
@@ -1,0 +1,21 @@
+//
+// Software Name: Orange Design System Charts
+// SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license.
+//
+
+export const DEFAULT_OUDS_COLORS_GREEN = {
+  color: [
+    'var(--ouds-charts-color-sequential-accent-2-tint-100)',
+    'var(--ouds-charts-color-sequential-accent-2-tint-200)',
+    'var(--ouds-charts-color-sequential-accent-2-tint-300)',
+    'var(--ouds-charts-color-sequential-accent-2-tint-400)',
+    'var(--ouds-charts-color-sequential-accent-2-tint-500)',
+    'var(--ouds-charts-color-sequential-accent-2-tint-600)',
+    'var(--ouds-charts-color-sequential-accent-2-tint-700)',
+    'var(--ouds-charts-color-sequential-accent-2-tint-800)',
+    'var(--ouds-charts-color-sequential-accent-2-tint-900)',
+  ],
+};

--- a/src/theme/default/OUDS.colors.highlight.ts
+++ b/src/theme/default/OUDS.colors.highlight.ts
@@ -1,0 +1,11 @@
+//
+// Software Name: Orange Design System Charts
+// SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license.
+//
+
+export const DEFAULT_OUDS_COLORS_HIGHLIGHT = {
+  color: ['var(--ouds-charts-color-highlight)', 'var(--ouds-charts-color-neutral)'],
+};

--- a/src/theme/default/OUDS.colors.pink.ts
+++ b/src/theme/default/OUDS.colors.pink.ts
@@ -1,0 +1,21 @@
+//
+// Software Name: Orange Design System Charts
+// SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license.
+//
+
+export const DEFAULT_OUDS_COLORS_PINK = {
+  color: [
+    'var(--ouds-charts-color-sequential-accent-3-tint-100)',
+    'var(--ouds-charts-color-sequential-accent-3-tint-200)',
+    'var(--ouds-charts-color-sequential-accent-3-tint-300)',
+    'var(--ouds-charts-color-sequential-accent-3-tint-400)',
+    'var(--ouds-charts-color-sequential-accent-3-tint-500)',
+    'var(--ouds-charts-color-sequential-accent-3-tint-600)',
+    'var(--ouds-charts-color-sequential-accent-3-tint-700)',
+    'var(--ouds-charts-color-sequential-accent-3-tint-800)',
+    'var(--ouds-charts-color-sequential-accent-3-tint-900)',
+  ],
+};

--- a/src/theme/default/OUDS.colors.purple.ts
+++ b/src/theme/default/OUDS.colors.purple.ts
@@ -1,0 +1,21 @@
+//
+// Software Name: Orange Design System Charts
+// SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license.
+//
+
+export const DEFAULT_OUDS_COLORS_PURPLE = {
+  color: [
+    'var(--ouds-charts-color-sequential-accent-4-tint-100)',
+    'var(--ouds-charts-color-sequential-accent-4-tint-200)',
+    'var(--ouds-charts-color-sequential-accent-4-tint-300)',
+    'var(--ouds-charts-color-sequential-accent-4-tint-400)',
+    'var(--ouds-charts-color-sequential-accent-4-tint-500)',
+    'var(--ouds-charts-color-sequential-accent-4-tint-600)',
+    'var(--ouds-charts-color-sequential-accent-4-tint-700)',
+    'var(--ouds-charts-color-sequential-accent-4-tint-800)',
+    'var(--ouds-charts-color-sequential-accent-4-tint-900)',
+  ],
+};

--- a/src/theme/default/OUDS.colors.single.ts
+++ b/src/theme/default/OUDS.colors.single.ts
@@ -1,0 +1,18 @@
+//
+// Software Name: Orange Design System Charts
+// SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license.
+//
+
+export const DEFAULT_OUDS_COLORS_SINGLE = {
+  color: [
+    'var(--ouds-charts-color-categorical-tier-1)',
+    'var(--ouds-charts-color-categorical-tier-6)',
+    'var(--ouds-charts-color-categorical-tier-7)',
+    'var(--ouds-charts-color-categorical-tier-2)',
+    'var(--ouds-charts-color-categorical-tier-5)',
+    'var(--ouds-charts-color-categorical-tier-10)',
+  ],
+};

--- a/src/theme/default/OUDS.colors.yellow.ts
+++ b/src/theme/default/OUDS.colors.yellow.ts
@@ -1,0 +1,21 @@
+//
+// Software Name: Orange Design System Charts
+// SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license.
+//
+
+export const DEFAULT_OUDS_COLORS_YELLOW = {
+  color: [
+    'var(--ouds-charts-color-sequential-accent-5-tint-100)',
+    'var(--ouds-charts-color-sequential-accent-5-tint-200)',
+    'var(--ouds-charts-color-sequential-accent-5-tint-300)',
+    'var(--ouds-charts-color-sequential-accent-5-tint-400)',
+    'var(--ouds-charts-color-sequential-accent-5-tint-500)',
+    'var(--ouds-charts-color-sequential-accent-5-tint-600)',
+    'var(--ouds-charts-color-sequential-accent-5-tint-700)',
+    'var(--ouds-charts-color-sequential-accent-5-tint-800)',
+    'var(--ouds-charts-color-sequential-accent-5-tint-900)',
+  ],
+};

--- a/src/theme/default/OUDS.common.ts
+++ b/src/theme/default/OUDS.common.ts
@@ -1,0 +1,11 @@
+//
+// Software Name: Orange Design System Charts
+// SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license.
+//
+
+export const DEFAULT_OUDS_COMMON = {
+  backgroundColor: 'var(--bs-body-bg, #fff)', // TODO: Replace it by `--bs-color-bg-primary` once OUDS is developed
+};

--- a/src/theme/default/OUDS.lines.axis.ts
+++ b/src/theme/default/OUDS.lines.axis.ts
@@ -1,0 +1,82 @@
+//
+// Software Name: Orange Design System Charts
+// SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license.
+//
+
+export const DEFAULT_OUDS_LINES_AXIS = {
+  categoryAxis: {
+    axisLine: {
+      show: true,
+      lineStyle: {
+        color: 'var(--ouds-charts-color-gridlines)',
+      },
+    },
+    axisLabel: {
+      show: true,
+      color: 'var(--bs-body-color, #000000)', // TODO: Replace once OUDS is developed by `--bs-color-content-default`
+    },
+    axisTick: {
+      show: false,
+      lineStyle: {
+        color: 'var(--ouds-charts-color-gridlines)',
+      },
+    },
+  },
+  valueAxis: {
+    axisLine: {
+      show: true,
+      lineStyle: {
+        color: 'var(--ouds-charts-color-gridlines)',
+      },
+    },
+    axisLabel: {
+      show: true,
+      color: 'var(--bs-body-color, #000000)', // TODO: Replace once OUDS is developed by `--bs-color-content-default`
+    },
+    axisTick: {
+      show: false,
+      lineStyle: {
+        color: 'var(--ouds-charts-color-gridlines)',
+      },
+    },
+  },
+  logAxis: {
+    axisLine: {
+      show: true,
+      lineStyle: {
+        color: 'var(--ouds-charts-color-gridlines)',
+      },
+    },
+    axisLabel: {
+      show: true,
+      color: 'var(--bs-body-color, #000000)', // TODO: Replace once OUDS is developed by `--bs-color-content-default`
+    },
+    axisTick: {
+      show: false,
+      lineStyle: {
+        color: 'var(--ouds-charts-color-gridlines)',
+      },
+    },
+  },
+  timeAxis: {
+    axisLine: {
+      show: true,
+      lineStyle: {
+        color: 'var(--ouds-charts-color-gridlines)',
+      },
+    },
+    axisLabel: {
+      show: true,
+      color: 'var(--bs-body-color, #000000)', // TODO: Replace once OUDS is developed by `--bs-color-content-default`
+    },
+    axisTick: {
+      show: false,
+      lineStyle: {
+        color: 'var(--ouds-charts-color-gridlines)',
+      },
+    },
+  },
+};

--- a/src/theme/ods-chart-theme.ts
+++ b/src/theme/ods-chart-theme.ts
@@ -36,6 +36,18 @@ import { DEFAULT_LINES_AXIS } from './default/ODS.lines.axis';
 import { ODS_CHARTS_CSS_VARIABLES } from './colors/colors-css-variables';
 import { ODSChartsThemeObserver } from './theme-observer/ods-charts-theme-observer';
 
+import { DEFAULT_OUDS_COLORS_BLUE } from './default/OUDS.colors.blue';
+import { DEFAULT_OUDS_COLORS_CATEGORICAL } from './default/OUDS.colors.categorical';
+import { DEFAULT_OUDS_COLORS_FUNCTIONAL } from './default/OUDS.colors.functional';
+import { DEFAULT_OUDS_COLORS_GREEN } from './default/OUDS.colors.green';
+import { DEFAULT_OUDS_COLORS_HIGHLIGHT } from './default/OUDS.colors.highlight';
+import { DEFAULT_OUDS_COLORS_PINK } from './default/OUDS.colors.pink';
+import { DEFAULT_OUDS_COLORS_PURPLE } from './default/OUDS.colors.purple';
+import { DEFAULT_OUDS_COLORS_SINGLE } from './default/OUDS.colors.single';
+import { DEFAULT_OUDS_COLORS_YELLOW } from './default/OUDS.colors.yellow';
+import { DEFAULT_OUDS_COMMON } from './default/OUDS.common'; // TODO: use when we can switch between ODS and OUDS
+import { DEFAULT_OUDS_LINES_AXIS } from './default/OUDS.lines.axis';
+
 /**
  * ODSChartsColorsSet is used for predefined color sets.
  *
@@ -54,6 +66,15 @@ import { ODSChartsThemeObserver } from './theme-observer/ods-charts-theme-observ
  * - {@link SEQUENTIAL_PINK} is the color set embedding all the Orange Design System pink colors.
  * - {@link SEQUENTIAL_PURPLE} is the color set embedding all the Orange Design System purple colors.
  * - {@link SEQUENTIAL_YELLOW} is the color set embedding all the Orange Design System yellow colors.
+ * - {@link OUDS_SEQUENTIAL_BLUE} is the color set embedding all the Orange Unified Design System blue colors. It's still experimental.
+ * - {@link OUDS_SEQUENTIAL_GREEN} is the color set embedding all the Orange Unified Design System green colors. It's still experimental.
+ * - {@link OUDS_SEQUENTIAL_PINK} is the color set embedding all the Orange Unified Design System pink colors. It's still experimental.
+ * - {@link OUDS_SEQUENTIAL_PURPLE} is the color set embedding all the Orange Unified Design System purple colors. It's still experimental.
+ * - {@link OUDS_SEQUENTIAL_YELLOW} is the color set embedding all the Orange Unified Design System yellow colors. It's still experimental.
+ * - {@link OUDS_CATEGORICAL} is the color set embedding all the Orange Unified Design System categorical colors. It's still experimental.
+ * - {@link OUDS_FUNCTIONAL} is the color set embedding all the Orange Unified Design System functional colors. It's still experimental.
+ * - {@link OUDS_HIGHLIGHT} is the color set embedding all the Orange Unified Design System highlight colors. It's still experimental.
+ * - {@link OUDS_SINGLE} is the color set embedding all the Orange Unified Design System single colors. It's still experimental.
  */
 export enum ODSChartsColorsSet {
   DEFAULT = 'default',
@@ -67,6 +88,15 @@ export enum ODSChartsColorsSet {
   SEQUENTIAL_PINK = 'pink',
   SEQUENTIAL_PURPLE = 'purple',
   SEQUENTIAL_YELLOW = 'yellow',
+  OUDS_SEQUENTIAL_BLUE = 'oudsBlue',
+  OUDS_SEQUENTIAL_GREEN = 'oudsGreen',
+  OUDS_SEQUENTIAL_PINK = 'oudsPink',
+  OUDS_SEQUENTIAL_PURPLE = 'oudsPurple',
+  OUDS_SEQUENTIAL_YELLOW = 'oudsYellow',
+  OUDS_CATEGORICAL = 'oudsCategorical',
+  OUDS_FUNCTIONAL = 'oudsFunctional',
+  OUDS_HIGHLIGHT = 'oudsHighlight',
+  OUDS_SINGLE = 'oudsSingle',
 }
 
 /**
@@ -197,6 +227,15 @@ const THEME: {
     pink: DEFAULT_COLORS_PINK,
     purple: DEFAULT_COLORS_PURPLE,
     yellow: DEFAULT_COLORS_YELLOW,
+    oudsBlue: DEFAULT_OUDS_COLORS_BLUE,
+    oudsGreen: DEFAULT_OUDS_COLORS_GREEN,
+    oudsPink: DEFAULT_OUDS_COLORS_PINK,
+    oudsPurple: DEFAULT_OUDS_COLORS_PURPLE,
+    oudsYellow: DEFAULT_OUDS_COLORS_YELLOW,
+    oudsCategorical: DEFAULT_OUDS_COLORS_CATEGORICAL,
+    oudsFunctional: DEFAULT_OUDS_COLORS_FUNCTIONAL,
+    oudsHighlight: DEFAULT_OUDS_COLORS_HIGHLIGHT,
+    oudsSingle: DEFAULT_OUDS_COLORS_SINGLE,
   },
   visualMapColors: {
     default: { visualMapColor: DEFAULT_COLORS.color },
@@ -210,6 +249,15 @@ const THEME: {
     pink: { visualMapColor: DEFAULT_COLORS_PINK.color },
     purple: { visualMapColor: DEFAULT_COLORS_PURPLE.color },
     yellow: { visualMapColor: DEFAULT_COLORS_YELLOW.color },
+    oudsBlue: { visualMapColor: DEFAULT_OUDS_COLORS_BLUE.color },
+    oudsGreen: { visualMapColor: DEFAULT_OUDS_COLORS_GREEN.color },
+    oudsPink: { visualMapColor: DEFAULT_OUDS_COLORS_PINK.color },
+    oudsPurple: { visualMapColor: DEFAULT_OUDS_COLORS_PURPLE.color },
+    oudsYellow: { visualMapColor: DEFAULT_OUDS_COLORS_YELLOW.color },
+    oudsCategorical: { visualMapColor: DEFAULT_OUDS_COLORS_CATEGORICAL.color },
+    oudsFunctional: { visualMapColor: DEFAULT_OUDS_COLORS_FUNCTIONAL.color },
+    oudsHighlight: { visualMapColor: DEFAULT_OUDS_COLORS_HIGHLIGHT.color },
+    oudsSingle: { visualMapColor: DEFAULT_OUDS_COLORS_SINGLE.color },
   },
   linesStyle: {
     broken: COMMON_LINE_STYLE_BROKEN,
@@ -296,7 +344,7 @@ export class ODSChartsTheme {
       }
       this._computedStyle = this._computedStyle ? this._computedStyle : null;
       if (!this._computedStyle) {
-        console.error('uunable to build computed style for chart css context', this.options.cssSelector, this.options.cssSelector);
+        console.error('unable to build computed style for chart css context', this.options.cssSelector, this.options.cssSelector);
       }
     }
     return this._computedStyle ? this._computedStyle : undefined;
@@ -320,11 +368,11 @@ export class ODSChartsTheme {
   }
 
   private replaceOneCssVar(css: any) {
-    let retunedValue = css;
-    if (this.options.cssSelector && 'string' === typeof retunedValue && !!this.computedStyle) {
+    let returnedValue = css;
+    if (this.options.cssSelector && 'string' === typeof returnedValue && !!this.computedStyle) {
       try {
         const regex = /var\(([^,]*),?(.*)\)/g;
-        const matches = retunedValue.match(regex);
+        const matches = returnedValue.match(regex);
         if (matches) {
           for (const foundVar of matches) {
             if (!(foundVar in this.cssVarsMapping)) {
@@ -355,13 +403,13 @@ export class ODSChartsTheme {
             }
 
             if (foundVar in this.cssVarsMapping) {
-              retunedValue = retunedValue.replace(foundVar, this.cssVarsMapping[foundVar]);
+              returnedValue = returnedValue.replace(foundVar, this.cssVarsMapping[foundVar]);
             }
           }
         }
       } catch (error) {}
     }
-    return retunedValue;
+    return returnedValue;
   }
 
   private replaceRecursivelyCssVars<T extends { [key: string]: any }>(subTreeConfig: T): T {


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

NA

### Description

Add OUDS color palettes that can be found here: https://unified-design-system.orange.com/472794e18/p/700671-colour.

### Motivation & Context

Be able to build charts using OUDS color palettes.

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Test checklist

Please check that the following tests projects are still working:

- [ ] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [ ] `test\angular-ng-boosted`
- [ ] `test/angular-echarts`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`
- [ ] `test/examples/timeseries-chart`
