### PR TITLE
fix(lib): graph size supervision removed the graph display animation effect

### DIFF
--- a/src/theme/resize/ods-chart-resize.ts
+++ b/src/theme/resize/ods-chart-resize.ts
@@ -6,7 +6,7 @@
 // This software is distributed under the MIT license.
 //
 
-import { type ECharts } from 'echarts';
+import { type EChartsOption, type ECharts, type ResizeOpts } from 'echarts';
 export class ODSChartsResize {
   private static sizeListeners: any = {};
   private observer: ResizeObserver | undefined = undefined;
@@ -61,7 +61,16 @@ export class ODSChartsResize {
 
   private resizeChart() {
     try {
-      this.echart.resize();
+      const chartOptions: EChartsOption = this.echart.getOption() as EChartsOption;
+      const opts: ResizeOpts = {};
+      if (chartOptions.animation) {
+        opts.animation = {
+          duration: 'number' === typeof chartOptions.animationDuration ? chartOptions.animationDuration : 1000,
+          easing: chartOptions.animationEasing ? chartOptions.animationEasing : 'cubicInOut',
+        };
+      }
+
+      this.echart.resize(opts);
     } catch (error) {
       this.removeListener();
     }


### PR DESCRIPTION
### Related issues

https://github.com/Orange-OpenSource/ods-charts/issues/559

### Description

By default ECharts has a display animation effect when drawing a chart.

But when you are using the `resize()` method on a chart, this default animation effect is ignored and it uses a specific animation configuration that need to be passed as a parameter to the `resize()` method (cf https://echarts.apache.org/en/api.html#echartsInstance.resize).

If you give no animation effect to be run to the `resize()` method, the display without any effect.

The ODS Charts libray uses the  `resize()` method in the [manageChartResize()](https://ods-charts.netlify.app/api/classes/odschartstheme#managechartresize) feature to redraw the graph

This fix uses the default animation effect set at the graph level when using the `resize()` method

### Motivation & Context

Keep the defaul Apache Echart animation effect

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Test checklist

Please check that the following tests projects are still working:

- [x] `docs/examples`
- [x] `test/angular-ngx-echarts`
- [x] `test\angular-ng-boosted`
- [x] `test/angular-echarts`
- [x] `test/html`
- [x] `test/react`
- [x] `test/vue`
- [x] `test/examples/bar-line-chart`
- [x] `test/examples/single-line-chart`
- [x] `test/examples/timeseries-chart`
