### PR TITLE
fix(lib): a mouse event during initialisation creates a popover/tooltip errorand disables the legend interaction

### DIFF
--- a/src/theme/ods-chart-theme.ts
+++ b/src/theme/ods-chart-theme.ts
@@ -789,30 +789,40 @@ export class ODSChartsTheme {
 
     themeOptions = this.replaceAllCssVars(themeOptions);
 
-    themeOptions = this.replaceAllCssVars(themeOptions);
-
     if (this.chartLegendManager) {
-      this.chartLegendManager.addLegend(
-        this.dataOptions,
-        displayedColors,
-        this.options.cssTheme as ODSChartsCSSThemeDefinition,
-        this.cssThemeName,
-        this.options.mode as ODSChartsMode
-      );
+      try {
+        this.chartLegendManager.addLegend(
+          this.dataOptions,
+          displayedColors,
+          this.options.cssTheme as ODSChartsCSSThemeDefinition,
+          this.cssThemeName,
+          this.options.mode as ODSChartsMode
+        );
+      } catch (error) {
+        console.error('unable to init Legend Manager', error);
+      }
     }
 
     if (this.chartResizeManager) {
-      this.chartResizeManager.addResizeManagement();
+      try {
+        this.chartResizeManager.addResizeManagement();
+      } catch (error) {
+        console.error('unable to init Resize Manager', error);
+      }
     }
 
     if (this.chartPopoverManager) {
-      this.chartPopoverManager.addPopoverManagement(
-        this.dataOptions,
-        themeOptions,
-        this.options.cssTheme as ODSChartsCSSThemeDefinition,
-        this.cssThemeName,
-        this.options.mode as ODSChartsMode
-      );
+      try {
+        this.chartPopoverManager.addPopoverManagement(
+          this.dataOptions,
+          themeOptions,
+          this.options.cssTheme as ODSChartsCSSThemeDefinition,
+          this.cssThemeName,
+          this.options.mode as ODSChartsMode
+        );
+      } catch (error) {
+        console.error('unable to init Popover Manager', error);
+      }
     }
 
     return themeOptions;

--- a/src/theme/popover/ods-chart-popover.ts
+++ b/src/theme/popover/ods-chart-popover.ts
@@ -422,8 +422,10 @@ export class ODSChartsPopover {
                 categoryLabel: string;
                 tooltipElements: ODSChartsPopoverItem[];
               } = this.getTooltipElements(params, legends);
-              if (elements && elements.tooltipElements.length > 0) {
-                this.displayPopup(window.event as MouseEvent, elements, cssTheme, this.mode);
+              if (elements && elements.tooltipElements.length > 0 && window.event) {
+                try {
+                  this.displayPopup(window.event as MouseEvent, elements, cssTheme, this.mode);
+                } catch (error) {}
               }
               return ' ';
             },


### PR DESCRIPTION
### Related issues

https://github.com/Orange-OpenSource/ods-charts/issues/588

### Description

Add error management on the thought error `Cannot read properties of undefined (reading 'pageY')`.

Add error management on every ODS Charts features initialisation

### Motivation & Context

Error at initialisation breaks the charts interactions

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Test checklist

Please check that the following tests projects are still working:

- [ ] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [ ] `test\angular-ng-boosted`
- [ ] `test/angular-echarts`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`
- [ ] `test/examples/timeseries-chart`
