### PR TITLE
feat(docs) : add dual y-axis example

### DIFF
--- a/docs/src/content/examples/bar-line-chart.md
+++ b/docs/src/content/examples/bar-line-chart.md
@@ -47,3 +47,23 @@ title: Bar + line Charts - Examples - ODS Charts
     </div>
   </div>
 </div>
+<div class="container-xxl d-flex flex-nowrap pt-3">
+  <div class="card w-100">
+    <div class="card-body">
+      <h5 class="card-title">Bar chart with dual axis line chart</h5>
+      <p class="card-text pe-5">Quantity values on the left axis with percentage trend line on the right axis.</p>
+      <button class="btn btn-icon btn-outline-secondary btn-edit" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Open in playground">
+        <svg width="1.25rem" height="1.25rem" fill="currentColor" aria-hidden="true">
+          <use xlink:href="#lightning-charge-fill" />
+        </svg>
+        <span class="visually-hidden">Open in playground using StackBlitz</span>
+      </button>
+      <div id="barLineDual"></div>
+      <script>
+        window.addEventListener('DOMContentLoaded', () => {
+          window.generateBarLineChart('barLineDual', false, false, false, true);
+        });
+      </script>
+    </div>
+  </div>
+</div>

--- a/docs/static/[version]/examples.js
+++ b/docs/static/[version]/examples.js
@@ -982,19 +982,37 @@ window.generateDatasetBarChart = async (id) => {
   displayChart('getBarChartConfiguration', id, option, undefined, ODSCharts.ODSChartsColorsSet.DARKER_TINTS);
 };
 
-window.generateBarLineChart = async (id, horizontal = false, grouped = false, stacked = true) => {
+window.generateBarLineChart = async (id, horizontal = false, grouped = false, stacked = true, dualAxis = false) => {
   // Specify the configuration items and data for the chart
   var option = {
     [horizontal ? 'yAxis' : 'xAxis']: {
       type: 'category',
       data: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
     },
-    [horizontal ? 'xAxis' : 'yAxis']: {},
+    [horizontal ? 'xAxis' : 'yAxis']: dualAxis
+      ? [
+          {
+            type: 'value',
+            name: 'Quantité',
+            position: 'left',
+          },
+          {
+            type: 'value',
+            name: 'Pourcentage',
+            position: 'right',
+            axisLabel: {
+              formatter: '{value} %',
+            },
+          },
+        ]
+      : {},
     series: [
       {
-        data: [10, 22, 28.8956454657, 23, 19, 15],
+        name: 'Quantité',
+        data: [120, 200, 150, 180, 230, 190],
         type: 'bar',
         stack: stacked ? true : undefined,
+        yAxisIndex: 0,
       },
     ]
       .concat(
@@ -1004,11 +1022,21 @@ window.generateBarLineChart = async (id, horizontal = false, grouped = false, st
                 data: [28.8956454657, 23, 19, 15, 18, 12],
                 type: 'bar',
                 stack: stacked ? true : undefined,
+                yAxisIndex: 0,
               },
             ]
           : []
       )
-      .concat([{ data: [12, 28.8956454657, 23, 15, 15, 18], type: 'line' }]),
+      .concat([
+        {
+          name: 'Taux de croissance',
+          data: [15, 25, 18, 22, 28, 20],
+          type: 'line',
+          yAxisIndex: dualAxis ? 1 : 0,
+          symbol: 'circle',
+          symbolSize: 8,
+        },
+      ]),
   };
   displayChart(
     'getLineAndBarChartConfiguration',


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues
https://github.com/Orange-OpenSource/ods-charts/issues/722

### Description

Add a sample of, a dual chart in the documentation.

### Motivation & Context
I think it  is missing.

### Types of change
I modify two files :
* docs/examples/bar-line-chart.html
* docs/examples/index.js

- New feature (non-breaking change which adds functionality)

### Test checklist

Please check that the following tests projects are still working:

- [x] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [ ] `test/angular-ng-boosted`
- [ ] `test/angular-echarts`
- [ ] `test/angular-14`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`
- [ ] `test/examples/timeseries-chart`
