### PR TITLE
fix(lib): The item line of a customized tooltip is not vertically align

### DIFF
--- a/src/theme/css-themes/css-themes.ts
+++ b/src/theme/css-themes/css-themes.ts
@@ -144,7 +144,7 @@ const BOOSTED5_Definition: ODSChartsCSSThemeDefinition = {
     },
   },
   popover: {
-    odsChartsPopoverLine: { classes: ['text-nowrap', 'd-flex', 'align-items-center', 'mb-1'] },
+    odsChartsPopoverLine: { classes: ['text-nowrap', 'd-flex', 'align-items-baseline', 'mb-1'] },
     odsChartsPopoverColorHolder: {
       classes: ['d-inline-block', 'me-1'],
     },
@@ -155,7 +155,7 @@ const BOOSTED5_Definition: ODSChartsCSSThemeDefinition = {
         height: '12px',
       },
     },
-    odsChartsPopoverText: { classes: ['flex-grow-1', 'd-flex', 'small'] },
+    odsChartsPopoverText: { classes: ['flex-grow-1', 'd-flex', 'align-items-baseline', 'small'] },
     odsChartsPopoverLabel: { classes: ['me-2', 'flex-grow-1'] },
     odsChartsPopoverValue: { classes: ['fw-bold'] },
   },
@@ -205,7 +205,7 @@ const BOOSTED4_Definition: ODSChartsCSSThemeDefinition = {
     },
   },
   popover: {
-    odsChartsPopoverLine: { classes: ['text-nowrap', 'd-flex', 'align-items-center', 'mb-1'] },
+    odsChartsPopoverLine: { classes: ['text-nowrap', 'd-flex', 'align-items-baseline', 'mb-1'] },
     odsChartsPopoverColorHolder: {
       classes: ['d-inline-block', 'mr-1'],
     },
@@ -216,7 +216,7 @@ const BOOSTED4_Definition: ODSChartsCSSThemeDefinition = {
         height: '12px',
       },
     },
-    odsChartsPopoverText: { classes: ['flex-grow-1', 'd-flex', 'small', 'm-0'] },
+    odsChartsPopoverText: { classes: ['flex-grow-1', 'd-flex', 'align-items-baseline', 'small', 'm-0'] },
     odsChartsPopoverLabel: { classes: ['mr-2', 'flex-grow-1'] },
     odsChartsPopoverValue: { classes: ['font-weight-bold'] },
   },

--- a/src/theme/legends/ods-chart-legends.ts
+++ b/src/theme/legends/ods-chart-legends.ts
@@ -223,6 +223,7 @@ export class ODSChartsLegends {
     let displayedSeriesNames = legendData.filter((legendLabel: string) => serieNames.includes(legendLabel));
     let displayedSeriesLabels = displayedSeriesNames;
     if (legendData.length !== displayedSeriesNames.length) {
+      // eslint-disable-next-line no-console
       console.info(
         `The legend data array contains some legends that do not match any series name. Legend data: [${legendData}]. Series names: [${serieNames}]. Displayed legends: [${displayedSeriesNames}]`
       );
@@ -235,6 +236,7 @@ export class ODSChartsLegends {
         displayedSeriesLabels = displayedSeriesLabels.filter((_legendLabel: string, index: number) => index < serieNames.length);
       }
       displayedSeriesNames = serieNames.filter((_serieName: string, index: number) => index < displayedSeriesLabels.length);
+      // eslint-disable-next-line no-console
       console.info(
         `Displayed legends labels have been mapped by their index, [${displayedSeriesLabels}] are the labels of the displayed series [${displayedSeriesNames}]`
       );

--- a/src/theme/popover/ods-chart-popover.ts
+++ b/src/theme/popover/ods-chart-popover.ts
@@ -108,12 +108,13 @@ const DEFAULT_NONE_CSS = `
   display: flex;
   margin-bottom: 5px;
   white-space: nowrap;
-  align-items: center;
+  align-items: baseline;
 }
 
 .ods-charts-no-css-lib .ods-charts-popover-text {
   flex-grow: 1;
   display: flex;
+  align-items: baseline;
   font-size: var(--ods-popover-body-font-size, 14px);
   font-weight: var(--ods-popover-body-font-weight, 700);
   line-height: var(--ods-popover-body-line-height, 1.11);


### PR DESCRIPTION
### Related issues

[<!-- Please link any related issues here. -->](https://github.com/Orange-OpenSource/ods-charts/issues/744)

### Description

Align legend items on baseline

### Motivation & Context

To keep alignment when the default font size is not used

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Test checklist

Please check that the following tests projects are still working:

- [X] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [ ] `test/angular-ng-boosted`
- [ ] `test/angular-echarts`
- [ ] `test/angular-14`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`
- [ ] `test/examples/timeseries-chart`
