### PR TITLE
fix(lib): The Apache ECharts legend should not be bold

### DIFF
--- a/docs/static/[version]/examples.js
+++ b/docs/static/[version]/examples.js
@@ -463,7 +463,8 @@ async function displayChart(
 
   legends =
     usedLegends === 'odscharts' &&
-    ((options.legend && options.legend.data && !options.legend.show) ||
+    (hasLegend ||
+      (options.legend && options.legend.data && !options.legend.show) ||
       (options.dataset && options.dataset.source) ||
       (options.series && 1 === options.series.length && 'pie' === options.series[0].type));
 
@@ -473,7 +474,7 @@ async function displayChart(
     iframe.contentDocument.getElementById(id + '_holder_with_legend').style.flexDirection = 'column';
   }
 
-  if (!legends && !hasLegend && usedLegends === 'odscharts') {
+  if (!legends && usedLegends === 'odscharts') {
     document.querySelectorAll(`#accordion_${id} .legends-style`).forEach((elt) => {
       elt.style.display = 'none';
     });

--- a/src/theme/ods-chart-theme.ts
+++ b/src/theme/ods-chart-theme.ts
@@ -675,7 +675,7 @@ export class ODSChartsTheme {
 
       const legend: any = {
         textStyle: {
-          fontWeight: 'bold',
+          fontWeight: 'var(--bs-body-font-weight, 400)',
           fontSize: 14,
           color:
             ODSChartsMode.DEFAULT === this.options.mode


### PR DESCRIPTION
### Related issues

https://github.com/Orange-OpenSource/ods-charts/issues/745

### Description

Forgot to set to normal size the font of Apache Echarts legends

### Motivation & Context

Have the ODS implemented when using Apache Echarts legends

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Test checklist

Please check that the following tests projects are still working:

- [X] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [ ] `test/angular-ng-boosted`
- [ ] `test/angular-echarts`
- [ ] `test/angular-14`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`
- [ ] `test/examples/timeseries-chart`
