### PR TITLE
fix(lib): Accept that different themes could cohabitate like it is done in ODS Charts tooltip use cases page

### DIFF
--- a/src/theme/css-themes/css-helper.ts
+++ b/src/theme/css-themes/css-helper.ts
@@ -64,8 +64,6 @@ export class ODSChartsCssHelper {
   public initComputedStyle(): boolean {
     if (!this._computedStyleInitialized) {
       if (!document.getElementById('ods-charts-style-' + this.cssThemeName) && ODS_CHARTS_CSS_VARIABLES[this.cssThemeName]) {
-        // clean any existing style previously inserted.
-        document.querySelectorAll('style[data-ods-charts-type="theme"]').forEach((el) => el.remove());
         const style = document.createElement('style');
         style.textContent = ODS_CHARTS_CSS_VARIABLES[this.cssThemeName];
         style.id = 'ods-charts-style-' + this.cssThemeName;


### PR DESCRIPTION
### Related issues

https://github.com/Orange-OpenSource/ods-charts/issues/738

### Description

The ODS Charts should not clean css set by other instance of the lib. 
It could happened if a same page, the developer decide to use BOOSTED for one charts and NONE for another

### Motivation & Context

Make the tooltip use case page works

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Test checklist

Please check that the following tests projects are still working:

- [X] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [ ] `test/angular-ng-boosted`
- [ ] `test/angular-echarts`
- [ ] `test/angular-14`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`
- [ ] `test/examples/timeseries-chart`
