### PR TITLE
fix(lib): serie specific color was used for all series of the same type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ ods-charts*.tgz
 /docs/static/\[version\]/api
 /test_local
 /docs/static/\[version\]/ods-charts.js
+/docs/static/\[version\]/ods-charts.js.map

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "install:angular-14": "npm i && npm run build && cd test/angular-14 && rm -rf node_modules package-lock.json && npm i && npm run build && cd ../.. && npm run serve:angular-14",
     "install:react": "npm i && npm run build && cd test/react && rm -rf node_modules package-lock.json && npm i && npm run build && cd ../.. && npm run serve:react",
     "install:vue": "npm i && npm run build && cd test/vue && rm -rf node_modules package-lock.json && npm i && npm run build && cd ../.. && npm run serve:vue",
-    "build": "webpack && cp ./dist/ods-charts.js ./docs/static/[version]/ods-charts.js && npx prettier --write ./docs/static/[version]/ods-charts.js",
+    "build": "webpack && cp ./dist/ods-charts.js ./docs/static/[version]/ods-charts.js && cp ./dist/ods-charts.js.map ./docs/static/[version]/ods-charts.js.map",
     "copyright-year": "node build/bump-copyright-year.mjs",
     "netlify": "npm run build && npm run docs:build",
     "prettier:check": "prettier --check .",

--- a/src/theme/ods-chart-theme.ts
+++ b/src/theme/ods-chart-theme.ts
@@ -535,37 +535,37 @@ export class ODSChartsTheme {
         themeOptions.series[index] = {};
         switch (dataOptions.series[index].type) {
           case 'line':
-            themeOptions.series[index] = { ...newTheme.line, markPoint: newTheme.markPoint };
+            themeOptions.series[index] = { ...cloneDeepObject(newTheme.line), markPoint: cloneDeepObject(newTheme.markPoint) };
             break;
           case 'bar':
-            themeOptions.series[index] = newTheme.bar;
+            themeOptions.series[index] = cloneDeepObject(newTheme.bar);
             break;
           case 'pie':
-            themeOptions.series[index] = newTheme.pie;
+            themeOptions.series[index] = cloneDeepObject(newTheme.pie);
             break;
           case 'scatter':
-            themeOptions.series[index] = newTheme.scatter;
+            themeOptions.series[index] = cloneDeepObject(newTheme.scatter);
             break;
           case 'boxplot':
-            themeOptions.series[index] = newTheme.boxplot;
+            themeOptions.series[index] = cloneDeepObject(newTheme.boxplot);
             break;
           case 'sankey':
-            themeOptions.series[index] = newTheme.sankey;
+            themeOptions.series[index] = cloneDeepObject(newTheme.sankey);
             break;
           case 'funnel':
-            themeOptions.series[index] = newTheme.funnel;
+            themeOptions.series[index] = cloneDeepObject(newTheme.funnel);
             break;
           case 'gauge':
-            themeOptions.series[index] = newTheme.gauge;
+            themeOptions.series[index] = cloneDeepObject(newTheme.gauge);
             break;
           case 'candlestick':
-            themeOptions.series[index] = newTheme.candlestick;
+            themeOptions.series[index] = cloneDeepObject(newTheme.candlestick);
             break;
           case 'graph':
-            themeOptions.series[index] = newTheme.graph;
+            themeOptions.series[index] = cloneDeepObject(newTheme.graph);
             break;
           case 'treemap':
-            themeOptions.series[index] = newTheme.map;
+            themeOptions.series[index] = cloneDeepObject(newTheme.map);
             break;
         }
         themeOptions.series[index] = { ...themeOptions.series[index], ...this.options.chartConfiguration?.getSerieConfiguration(dataOptions.series[index]) };


### PR DESCRIPTION
### Related issues

https://github.com/Orange-OpenSource/ods-charts/issues/740

### Description

When the color of one serie was specified, all the series got the same color.

This was due to the fact the theme specific configuration was not cloned and then shared between series. The final merge operations merged each serie configuration into  the theme specific configuration, common to all series

### Motivation & Context

Fix the bug

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Test checklist

- [X] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [ ] `test/angular-ng-boosted`
- [ ] `test/angular-echarts`
- [ ] `test/angular-14`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`
- [ ] `test/examples/timeseries-chart`
