### PR TITLE
fix(doc): Examples and use cases pages do not open playground in stakblitz with the last version but stay in 0.2.0

### DIFF
--- a/docs/src/assets/stackblitz.js
+++ b/docs/src/assets/stackblitz.js
@@ -10,13 +10,13 @@ document.querySelectorAll('.btn-edit').forEach((btn) => {
     document.getElementById(`collapse_content_2_${id}`)?.classList.remove('d-block');
     document.getElementById(`${id}_viewCode`)?.classList.remove('d-block');
 
-    openChartsSnippet(htmlText, codeText);
+    const libVersion = document.querySelector('[data-ods-charts-version]').getAttribute('data-ods-charts-version');
+
+    openChartsSnippet(htmlText, codeText, libVersion);
   });
 });
 
-const openChartsSnippet = (htmlSnippet, jsSnippet) => {
-  console.log(htmlSnippet, jsSnippet);
-
+const openChartsSnippet = (htmlSnippet, jsSnippet, libVersion) => {
   const project = {
     files: {
       'index.html': `<!doctype html>
@@ -41,7 +41,7 @@ const openChartsSnippet = (htmlSnippet, jsSnippet) => {
     <title>ODS Charts example</title>
 
     <${'script'} src="https://cdn.jsdelivr.net/npm/echarts@5.6.0/dist/echarts.min.js"></${'script'}>
-    <${'script'} src="https://cdn.jsdelivr.net/npm/ods-charts@0.2.0/dist/ods-charts.min.js"></${'script'}>
+    <${'script'} src="https://cdn.jsdelivr.net/npm/ods-charts@${libVersion}/dist/ods-charts.min.js"></${'script'}>
   </head>
   <body class="p-3 m-0 border-0" style="height: 65vh;">
     <!-- Example Code -->

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -4,6 +4,7 @@ import Header from '@components/Header.astro'
 import Footer from '@components/Footer.astro'
 import Scripts from '@components/Scripts.astro'
 import BoostedScript from "@components/BoostedScript.astro"
+import { getConfig } from '@libs/config'
 
 interface Props {
   data: {
@@ -13,10 +14,11 @@ interface Props {
 }
 
 const { data, removeBoosted } = Astro.props
+const libVersion = getConfig().lib_version
 ---
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-ods-charts-version={libVersion}>
   <head>
     <Head title={data.title || 'ODS Charts'} />
     <slot name="head-scripts" />


### PR DESCRIPTION
### Related issues

https://github.com/Orange-OpenSource/ods-charts/issues/751

### Description

The version of ods-charts was hard coded in POST opening stackblitz

### Motivation & Context

To be able to run ODS Charts example with the last PATCH of the version corresponding to the current minor page documentation

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Test checklist

Please check that the following tests projects are still working:

- [X] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [ ] `test/angular-ng-boosted`
- [ ] `test/angular-echarts`
- [ ] `test/angular-14`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`
- [ ] `test/examples/timeseries-chart`
