### PR TITLE
fix(eslint) eslint shouldn't fix

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,4 @@
 {
-  "*.{ts,js,mjs}": ["eslint --cache --cache-location .eslintcache --fix"],
+  "*.{ts,js,mjs}": ["eslint --cache --cache-location .eslintcache"],
   "*.{ts,js,mjs,json,md,yml,yaml}": ["prettier --write"]
 }


### PR DESCRIPTION
### Description

This pull request makes a minor update to the `.lintstagedrc.json` configuration by removing the `--fix` flag from the ESLint command. This means ESLint will now only report issues without automatically fixing them during the lint-staged run.

Next to :
- https://github.com/Orange-OpenSource/ods-charts/pull/752
- https://github.com/Orange-OpenSource/ods-charts/pull/749

### Test checklist

Please check that the following tests projects are still working:

- [ ] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [ ] `test/angular-ng-boosted`
- [ ] `test/angular-echarts`
- [ ] `test/angular-14`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`
- [ ] `test/examples/timeseries-chart`
