### PR TITLE
fix(doc): Strange colors added in ODS Charts colors sets page

### DIFF
--- a/src/theme/ODS.project.ts
+++ b/src/theme/ODS.project.ts
@@ -502,7 +502,7 @@ export const ODS_PROJECT: EChartsProject = {
     symbolSize: 4,
     symbol: 'emptyCircle',
     smooth: false,
-    color: ['#4bb4e6', '#50be87', '#ffb4e6', '#a885d8', '#ffd200'],
+    color: [],
     label: {
       color: 'var(--bs-body-color, #000000)',
     },

--- a/src/theme/ods-chart-theme.ts
+++ b/src/theme/ods-chart-theme.ts
@@ -11,7 +11,6 @@ import { COMMON_LINE_STYLE_POINTS } from './common/ODS.line-style.with-points';
 import { COMMON_LINE_STYLE_SMOOTH } from './common/ODS.line-style.smooth';
 import { EChartsProject, ODS_PROJECT } from './ODS.project';
 import { ODSChartsLegends } from './legends/ods-chart-legends';
-import { mergeObjects } from '../tools/merge-objects';
 import { ODSChartsResize } from './resize/ods-chart-resize';
 import { ODSChartsCSSThemeDefinition, ODSChartsCSSThemes, ODSChartsCSSThemesNames } from './css-themes/css-themes';
 import { buildHash, getStringValue } from '../tools/hash';
@@ -46,6 +45,7 @@ import { DEFAULT_OUDS_COLORS_PURPLE } from './default/OUDS.colors.purple';
 import { DEFAULT_OUDS_COLORS_SINGLE } from './default/OUDS.colors.single';
 import { DEFAULT_OUDS_COLORS_YELLOW } from './default/OUDS.colors.yellow';
 import { ODSChartsConfiguration } from '../ods-charts';
+import { mergeObjectsAndArrays, mergeObjectsAndReplaceArrays } from '../tools/merge-objects';
 // import { DEFAULT_OUDS_COMMON } from './default/OUDS.common'; // TODO: use when we can switch between ODS and OUDS
 // import { DEFAULT_OUDS_LINES_AXIS } from './default/OUDS.lines.axis';
 
@@ -410,15 +410,15 @@ export class ODSChartsTheme {
 
     const theme: EChartsProject = cloneDeepObject(ODS_PROJECT);
 
-    mergeObjects(theme, cloneDeepObject(THEME.common));
+    mergeObjectsAndReplaceArrays(theme, cloneDeepObject(THEME.common));
 
-    mergeObjects(theme, cloneDeepObject(THEME.linesAxis));
+    mergeObjectsAndReplaceArrays(theme, cloneDeepObject(THEME.linesAxis));
 
     if (typeof options.colors === 'string') {
-      mergeObjects(theme, cloneDeepObject(THEME.colors[options.colors]));
-      mergeObjects(theme, cloneDeepObject(THEME.visualMapColors[options.colors]));
+      mergeObjectsAndReplaceArrays(theme, cloneDeepObject(THEME.colors[options.colors]));
+      mergeObjectsAndReplaceArrays(theme, cloneDeepObject(THEME.visualMapColors[options.colors]));
     } else {
-      mergeObjects(
+      mergeObjectsAndReplaceArrays(
         theme,
         cloneDeepObject({
           color: options.colors.map((color) => ('string' === typeof color ? color : THEME.colors[color.colorPalette].color[color.colorIndex])),
@@ -429,7 +429,7 @@ export class ODSChartsTheme {
       );
     }
 
-    mergeObjects(
+    mergeObjectsAndReplaceArrays(
       theme,
       cloneDeepObject(
         THEME.linesStyle[
@@ -505,7 +505,7 @@ export class ODSChartsTheme {
    */
   private calculateNewThemeAndAddItInThemeOptions(themeOptions: any, dataOptions: any): any {
     const newTheme = this.calculateTheme();
-    mergeObjects(
+    mergeObjectsAndArrays(
       themeOptions,
       {
         color: newTheme.color,
@@ -582,16 +582,16 @@ export class ODSChartsTheme {
       if (dataOptions[axisType]) {
         switch (dataOptions[axisType].type) {
           case 'category':
-            themeOptions[axisType] = mergeObjects(themeOptions[axisType], newTheme.categoryAxis);
+            themeOptions[axisType] = mergeObjectsAndReplaceArrays(themeOptions[axisType], newTheme.categoryAxis);
             break;
           case 'value':
-            themeOptions[axisType] = mergeObjects(themeOptions[axisType], newTheme.valueAxis);
+            themeOptions[axisType] = mergeObjectsAndReplaceArrays(themeOptions[axisType], newTheme.valueAxis);
             break;
           case 'log':
-            themeOptions[axisType] = mergeObjects(themeOptions[axisType], newTheme.logAxis);
+            themeOptions[axisType] = mergeObjectsAndReplaceArrays(themeOptions[axisType], newTheme.logAxis);
             break;
           case 'time':
-            themeOptions[axisType] = mergeObjects(themeOptions[axisType], newTheme.timeAxis);
+            themeOptions[axisType] = mergeObjectsAndReplaceArrays(themeOptions[axisType], newTheme.timeAxis);
             break;
         }
       }
@@ -874,6 +874,6 @@ export class ODSChartsTheme {
     }
 
     const { themeOptions, dataOptions } = this.getThemeOptions();
-    return mergeObjects(themeOptions, dataOptions);
+    return mergeObjectsAndArrays(themeOptions, dataOptions);
   }
 }

--- a/src/theme/popover/ods-chart-popover.ts
+++ b/src/theme/popover/ods-chart-popover.ts
@@ -7,7 +7,7 @@
 //
 
 import { ODSChartsCSSThemeDefinition, ODSChartsCSSThemesNames, ODSChartsItemCSSDefinition } from '../css-themes/css-themes';
-import { mergeObjects, isVarArray } from '../../tools/merge-objects';
+import { isVarArray, mergeObjectsAndReplaceArrays } from '../../tools/merge-objects';
 import {
   DEFAULT_ARROW_SIZE,
   ODSChartsPopoverAxisPointer,
@@ -250,7 +250,7 @@ export class ODSChartsPopover {
                   : isVarArray(param.value)
                     ? undefined
                     : param.value;
-            const element: ODSChartsPopoverItem = mergeObjects(cloneDeepObject(param), {
+            const element: ODSChartsPopoverItem = mergeObjectsAndReplaceArrays(cloneDeepObject(param), {
               markerColor: param.color,
               itemValue: itemValue,
               label: legendLabel || '',
@@ -290,7 +290,7 @@ export class ODSChartsPopover {
     } catch (error) {}
 
     if (this.popoverConfig.enabled) {
-      mergeObjects(popoverOptions, {
+      mergeObjectsAndReplaceArrays(popoverOptions, {
         tooltip: {
           appendTo: 'body',
         },
@@ -307,13 +307,13 @@ export class ODSChartsPopover {
         },
       });
       if (!this.popoverConfig.tooltip) {
-        mergeObjects(popoverOptions, {
+        mergeObjectsAndReplaceArrays(popoverOptions, {
           tooltip: { triggerOn: 'click', alwaysShowContent: false },
         });
       }
 
       if (!(this.popoverDefinition as ODSChartsPopoverDefinitionWithRenderer).getOrCreatePopupInstance) {
-        mergeObjects(popoverOptions, {
+        mergeObjectsAndReplaceArrays(popoverOptions, {
           tooltip: {
             position: (
               mousePosition: number[],
@@ -402,7 +402,7 @@ export class ODSChartsPopover {
           },
         });
       } else {
-        mergeObjects(popoverOptions, {
+        mergeObjectsAndReplaceArrays(popoverOptions, {
           tooltip: {
             formatter: (params: ODSChartsPopoverItem[] | ODSChartsPopoverItem) => {
               if (!isVarArray(params)) {
@@ -468,18 +468,18 @@ export class ODSChartsPopover {
       }
 
       if (!this.popoverConfig.shared && 'none' === this.popoverConfig.axisPointer) {
-        mergeObjects(popoverOptions, { tooltip: { trigger: 'item' } });
+        mergeObjectsAndReplaceArrays(popoverOptions, { tooltip: { trigger: 'item' } });
       } else {
-        mergeObjects(popoverOptions, { tooltip: { trigger: 'axis' } });
+        mergeObjectsAndReplaceArrays(popoverOptions, { tooltip: { trigger: 'axis' } });
       }
     } else {
-      mergeObjects(popoverOptions, {
+      mergeObjectsAndReplaceArrays(popoverOptions, {
         tooltip: {
           triggerOn: 'none',
         },
       });
     }
-    mergeObjects(themeOptions, popoverOptions);
+    mergeObjectsAndReplaceArrays(themeOptions, popoverOptions);
   }
 
   private getPopupContentLine(element: ODSChartsPopoverItem, cssTheme: ODSChartsCSSThemeDefinition, mode: ODSChartsMode): string {

--- a/src/tools/merge-objects.spec.ts
+++ b/src/tools/merge-objects.spec.ts
@@ -1,0 +1,499 @@
+//
+// Software Name: Orange Design System Charts
+// SPDX-FileCopyrightText: Copyright (c) 2023 - 2025 Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license.
+//
+
+import 'jasmine';
+import { isVarArray, isVarObject, isVarFunction, mergeObjectsAndReplaceArrays, mergeObjectsAndArrays } from './merge-objects';
+
+describe('isVarArray', () => {
+  it('should return true for arrays', () => {
+    expect(isVarArray([])).toBe(true);
+    expect(isVarArray([1, 2, 3])).toBe(true);
+    expect(isVarArray(['a', 'b'])).toBe(true);
+  });
+
+  it('should return false for non-arrays', () => {
+    expect(isVarArray({})).toBe(false);
+    expect(isVarArray('string')).toBe(false);
+    expect(isVarArray(123)).toBe(false);
+    expect(isVarArray(null)).toBe(false);
+    expect(isVarArray(undefined)).toBe(false);
+  });
+});
+
+describe('isVarObject', () => {
+  it('should return true for objects', () => {
+    expect(isVarObject({})).toBe(true);
+    expect(isVarObject({ a: 1 })).toBe(true);
+    expect(isVarObject({ nested: { obj: true } })).toBe(true);
+  });
+
+  it('should return false for arrays', () => {
+    expect(isVarObject([])).toBe(false);
+    expect(isVarObject([1, 2, 3])).toBe(false);
+  });
+
+  it('should return false for primitives', () => {
+    expect(isVarObject('string')).toBe(false);
+    expect(isVarObject(123)).toBe(false);
+    expect(isVarObject(true)).toBe(false);
+    expect(isVarObject(null)).toBe(false);
+    expect(isVarObject(undefined)).toBe(false);
+  });
+});
+
+describe('isVarFunction', () => {
+  it('should return true for functions', () => {
+    expect(isVarFunction(() => {})).toBe(true);
+    expect(isVarFunction(function () {})).toBe(true);
+    expect(isVarFunction(isVarFunction)).toBe(true);
+  });
+
+  it('should return false for non-functions', () => {
+    expect(isVarFunction({})).toBe(false);
+    expect(isVarFunction([])).toBe(false);
+    expect(isVarFunction('string')).toBe(false);
+    expect(isVarFunction(123)).toBe(false);
+    expect(isVarFunction(null)).toBe(false);
+    expect(isVarFunction(undefined)).toBe(false);
+  });
+});
+
+describe('mergeObjectsAndReplaceArrays', () => {
+  it('should merge two simple objects', () => {
+    const obj1 = { a: 1, b: 2 };
+    const obj2 = { b: 3, c: 4 };
+    const result = mergeObjectsAndReplaceArrays(obj1, obj2);
+    expect(result).toEqual({ a: 1, b: 3, c: 4 });
+  });
+
+  it('should merge nested objects', () => {
+    const obj1 = {
+      a: 1,
+      nested: {
+        x: 10,
+        y: 20,
+      },
+    };
+    const obj2 = {
+      nested: {
+        y: 30,
+        z: 40,
+      },
+      b: 2,
+    };
+    const result = mergeObjectsAndReplaceArrays(obj1, obj2);
+    expect(result).toEqual({
+      a: 1,
+      nested: {
+        x: 10,
+        y: 30,
+        z: 40,
+      },
+      b: 2,
+    });
+  });
+
+  it('should merge arrays by replacement', () => {
+    const obj1 = { arr: [1, 2, 3] };
+    const obj2 = { arr: [10, 20] };
+    const result = mergeObjectsAndReplaceArrays(obj1, obj2);
+    expect(result).toEqual({ arr: [10, 20] });
+  });
+
+  it('should merge multiple objects', () => {
+    const obj1 = { a: 1 };
+    const obj2 = { b: 2 };
+    const obj3 = { c: 3 };
+    const obj4 = { d: 4 };
+    const result = mergeObjectsAndReplaceArrays(obj1, obj2, obj3, obj4);
+    expect(result).toEqual({ a: 1, b: 2, c: 3, d: 4 });
+  });
+
+  it('should merge deeply nested structures', () => {
+    const obj1 = {
+      level1: {
+        level2: {
+          level3: {
+            value: 'original',
+          },
+        },
+      },
+    };
+    const obj2 = {
+      level1: {
+        level2: {
+          level3: {
+            value: 'updated',
+            newValue: 'new',
+          },
+        },
+      },
+    };
+    const result = mergeObjectsAndReplaceArrays(obj1, obj2);
+    expect(result).toEqual({
+      level1: {
+        level2: {
+          level3: {
+            value: 'updated',
+            newValue: 'new',
+          },
+        },
+      },
+    });
+  });
+
+  it('should override primitive values', () => {
+    const obj1 = { a: 1, b: 'string', c: true };
+    const obj2 = { a: 10, b: 'updated', c: false };
+    const result = mergeObjectsAndReplaceArrays(obj1, obj2);
+    expect(result).toEqual({ a: 10, b: 'updated', c: false });
+  });
+
+  it('should handle empty objects', () => {
+    const obj1 = {};
+    const obj2 = { a: 1 };
+    const result = mergeObjectsAndReplaceArrays(obj1, obj2);
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it('should handle merging with arrays containing objects', () => {
+    const obj1 = {
+      items: [
+        { id: 1, name: 'item1' },
+        { id: 2, name: 'item2' },
+      ],
+    };
+    const obj2 = {
+      items: [{ id: 1, name: 'updated' }],
+    };
+    const result = mergeObjectsAndReplaceArrays(obj1, obj2);
+    expect(result).toEqual({
+      items: [{ id: 1, name: 'updated' }],
+    });
+  });
+
+  it('should mutate the first object', () => {
+    const obj1: any = { a: 1 };
+    const obj2 = { b: 2 };
+    const result = mergeObjectsAndReplaceArrays(obj1, obj2);
+    expect(result).toBe(obj1);
+    expect(obj1).toEqual({ a: 1, b: 2 });
+  });
+
+  it('should handle complex mixed structures', () => {
+    const obj1 = {
+      config: {
+        settings: {
+          theme: 'dark',
+          colors: ['red', 'blue'],
+        },
+        options: {
+          enabled: true,
+        },
+      },
+    };
+    const obj2 = {
+      config: {
+        settings: {
+          colors: ['green'],
+          fontSize: 14,
+        },
+        options: {
+          enabled: false,
+          timeout: 3000,
+        },
+      },
+    };
+    const result = mergeObjectsAndReplaceArrays(obj1, obj2);
+    expect(result).toEqual({
+      config: {
+        settings: {
+          theme: 'dark',
+          colors: ['green'],
+          fontSize: 14,
+        },
+        options: {
+          enabled: false,
+          timeout: 3000,
+        },
+      },
+    });
+  });
+
+  it('should handle null and undefined values', () => {
+    const obj1 = { a: 1, b: null, c: undefined };
+    const obj2 = { a: null, b: 2, d: undefined };
+    const result = mergeObjectsAndReplaceArrays(obj1, obj2);
+    expect(result).toEqual({ a: null, b: 2, c: undefined, d: undefined });
+  });
+
+  it('should work with small initial color set', () => {
+    const obj1 = {
+      color: ['#4bb4e6', '#50be87', '#ffb4e6', '#a885d8', '#ffd200'],
+      visualMap: {
+        color: ['#085ebd', '#3179c8', '#5a94d3', '#84afde', '#adc9e9', '#d6e4f4'],
+      },
+      markPoint: {
+        label: {
+          color: 'var(--bs-body-color, #000000)',
+        },
+        emphasis: {
+          label: {
+            color: 'var(--bs-body-color, #000000)',
+          },
+        },
+      },
+    };
+    const obj2 = {
+      color: ['var(--ouds-charts-color-highlight)', 'var(--ouds-charts-color-neutral)'],
+    };
+    const obj3 = {
+      visualMapColor: ['var(--ouds-charts-color-highlight)', 'var(--ouds-charts-color-neutral)'],
+    };
+
+    const result = mergeObjectsAndReplaceArrays(obj1, obj2, obj3);
+    expect(result.color).toEqual(['var(--ouds-charts-color-highlight)', 'var(--ouds-charts-color-neutral)']);
+    expect(result.visualMapColor).toEqual(['var(--ouds-charts-color-highlight)', 'var(--ouds-charts-color-neutral)']);
+  });
+});
+
+describe('mergeObjectsAndArrays', () => {
+  it('should merge two simple objects', () => {
+    const obj1 = { a: 1, b: 2 };
+    const obj2 = { b: 3, c: 4 };
+    const result = mergeObjectsAndArrays(obj1, obj2);
+    expect(result).toEqual({ a: 1, b: 3, c: 4 });
+  });
+
+  it('should merge nested objects', () => {
+    const obj1 = {
+      a: 1,
+      nested: {
+        x: 10,
+        y: 20,
+      },
+    };
+    const obj2 = {
+      nested: {
+        y: 30,
+        z: 40,
+      },
+      b: 2,
+    };
+    const result = mergeObjectsAndArrays(obj1, obj2);
+    expect(result).toEqual({
+      a: 1,
+      nested: {
+        x: 10,
+        y: 30,
+        z: 40,
+      },
+      b: 2,
+    });
+  });
+
+  it('should merge arrays by index', () => {
+    const obj1 = { arr: [1, 2, 3] };
+    const obj2 = { arr: [10, 20] };
+    const result = mergeObjectsAndArrays(obj1, obj2);
+    expect(result).toEqual({ arr: [10, 20, 3] });
+  });
+
+  it('should extend array when obj2 has more elements', () => {
+    const obj1 = { arr: [1, 2] };
+    const obj2 = { arr: [10, 20, 30, 40] };
+    const result = mergeObjectsAndArrays(obj1, obj2);
+    expect(result).toEqual({ arr: [10, 20, 30, 40] });
+  });
+
+  it('should merge multiple objects', () => {
+    const obj1 = { a: 1 };
+    const obj2 = { b: 2 };
+    const obj3 = { c: 3 };
+    const obj4 = { d: 4 };
+    const result = mergeObjectsAndArrays(obj1, obj2, obj3, obj4);
+    expect(result).toEqual({ a: 1, b: 2, c: 3, d: 4 });
+  });
+
+  it('should merge deeply nested structures', () => {
+    const obj1 = {
+      level1: {
+        level2: {
+          level3: {
+            value: 'original',
+          },
+        },
+      },
+    };
+    const obj2 = {
+      level1: {
+        level2: {
+          level3: {
+            value: 'updated',
+            newValue: 'new',
+          },
+        },
+      },
+    };
+    const result = mergeObjectsAndArrays(obj1, obj2);
+    expect(result).toEqual({
+      level1: {
+        level2: {
+          level3: {
+            value: 'updated',
+            newValue: 'new',
+          },
+        },
+      },
+    });
+  });
+
+  it('should override primitive values', () => {
+    const obj1 = { a: 1, b: 'string', c: true };
+    const obj2 = { a: 10, b: 'updated', c: false };
+    const result = mergeObjectsAndArrays(obj1, obj2);
+    expect(result).toEqual({ a: 10, b: 'updated', c: false });
+  });
+
+  it('should handle empty objects', () => {
+    const obj1 = {};
+    const obj2 = { a: 1 };
+    const result = mergeObjectsAndArrays(obj1, obj2);
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it('should handle merging with arrays containing objects by index', () => {
+    const obj1 = {
+      items: [
+        { id: 1, name: 'item1' },
+        { id: 2, name: 'item2' },
+      ],
+    };
+    const obj2 = {
+      items: [{ id: 1, name: 'updated' }],
+    };
+    const result = mergeObjectsAndArrays(obj1, obj2);
+    expect(result).toEqual({
+      items: [
+        { id: 1, name: 'updated' },
+        { id: 2, name: 'item2' },
+      ],
+    });
+  });
+
+  it('should merge nested arrays with objects', () => {
+    const obj1 = {
+      data: [
+        { value: 10, label: 'A' },
+        { value: 20, label: 'B' },
+        { value: 30, label: 'C' },
+      ],
+    };
+    const obj2 = {
+      data: [{ value: 100 }, { value: 200 }],
+    };
+    const result = mergeObjectsAndArrays(obj1, obj2);
+    expect(result).toEqual({
+      data: [
+        { value: 100, label: 'A' },
+        { value: 200, label: 'B' },
+        { value: 30, label: 'C' },
+      ],
+    });
+  });
+
+  it('should mutate the first object', () => {
+    const obj1: any = { a: 1 };
+    const obj2 = { b: 2 };
+    const result = mergeObjectsAndArrays(obj1, obj2);
+    expect(result).toBe(obj1);
+    expect(obj1).toEqual({ a: 1, b: 2 });
+  });
+
+  it('should handle complex mixed structures with array merging', () => {
+    const obj1 = {
+      config: {
+        settings: {
+          theme: 'dark',
+          colors: ['red', 'blue', 'yellow'],
+        },
+        options: {
+          enabled: true,
+        },
+      },
+    };
+    const obj2 = {
+      config: {
+        settings: {
+          colors: ['green', 'purple'],
+          fontSize: 14,
+        },
+        options: {
+          enabled: false,
+          timeout: 3000,
+        },
+      },
+    };
+    const result = mergeObjectsAndArrays(obj1, obj2);
+    expect(result).toEqual({
+      config: {
+        settings: {
+          theme: 'dark',
+          colors: ['green', 'purple', 'yellow'],
+          fontSize: 14,
+        },
+        options: {
+          enabled: false,
+          timeout: 3000,
+        },
+      },
+    });
+  });
+
+  it('should handle null and undefined values', () => {
+    const obj1 = { a: 1, b: null, c: undefined };
+    const obj2 = { a: null, b: 2, d: undefined };
+    const result = mergeObjectsAndArrays(obj1, obj2);
+    expect(result).toEqual({ a: null, b: 2, c: undefined, d: undefined });
+  });
+
+  it('should merge arrays with primitive values', () => {
+    const obj1 = {
+      numbers: [1, 2, 3, 4, 5],
+      strings: ['a', 'b', 'c'],
+    };
+    const obj2 = {
+      numbers: [10, 20],
+      strings: ['x', 'y', 'z', 'w'],
+    };
+    const result = mergeObjectsAndArrays(obj1, obj2);
+    expect(result).toEqual({
+      numbers: [10, 20, 3, 4, 5],
+      strings: ['x', 'y', 'z', 'w'],
+    });
+  });
+
+  it('should merge deeply nested arrays', () => {
+    const obj1 = {
+      matrix: [
+        [1, 2, 3],
+        [4, 5, 6],
+      ],
+    };
+    const obj2 = {
+      matrix: [[10, 20], [40]],
+    };
+    const result = mergeObjectsAndArrays(obj1, obj2);
+    expect(result).toEqual({
+      matrix: [
+        [10, 20, 3],
+        [40, 5, 6],
+      ],
+    });
+  });
+});

--- a/src/tools/merge-objects.ts
+++ b/src/tools/merge-objects.ts
@@ -7,23 +7,31 @@
 //
 
 export function isVarArray(obj: any) {
-  return obj && Array.isArray(obj);
+  return !!obj && Array.isArray(obj);
 }
 export function isVarObject(obj: any) {
-  return typeof obj === 'object' && !isVarArray(obj);
+  return !!obj && typeof obj === 'object' && !isVarArray(obj);
 }
 export function isVarFunction(obj: any) {
-  return typeof obj === 'function';
+  return !!obj && typeof obj === 'function';
 }
 
-export function mergeObjects(obj1: any, obj2: any, ...obj: any) {
+export function mergeObjectsAndArrays(obj1: any, obj2: any, ...obj: any) {
+  return mergeObjects(true, obj1, obj2, ...obj);
+}
+
+export function mergeObjectsAndReplaceArrays(obj1: any, obj2: any, ...obj: any) {
+  return mergeObjects(false, obj1, obj2, ...obj);
+}
+
+function mergeObjects(mergeArray: boolean, obj1: any, obj2: any, ...obj: any) {
   if (obj && isVarArray(obj) && 0 < obj.length) {
-    return mergeObjects(mergeObjects(obj1, obj2), obj[0], ...obj.slice(1));
+    return mergeObjects(mergeArray, mergeObjects(mergeArray, obj1, obj2), obj[0], ...obj.slice(1));
   }
-  if ((isVarObject(obj1) && isVarObject(obj2)) || (isVarArray(obj1) && isVarArray(obj2))) {
+  if ((isVarObject(obj1) && isVarObject(obj2)) || (mergeArray && isVarArray(obj1) && isVarArray(obj2))) {
     for (const obj2Key of Object.keys(obj2)) {
-      if ((isVarObject(obj1[obj2Key]) && isVarObject(obj2[obj2Key])) || (isVarArray(obj1[obj2Key]) && isVarArray(obj2[obj2Key]))) {
-        mergeObjects(obj1[obj2Key], obj2[obj2Key]);
+      if ((isVarObject(obj1[obj2Key]) && isVarObject(obj2[obj2Key])) || (mergeArray && isVarArray(obj1[obj2Key]) && isVarArray(obj2[obj2Key]))) {
+        mergeObjects(mergeArray, obj1[obj2Key], obj2[obj2Key]);
       } else {
         obj1[obj2Key] = obj2[obj2Key];
       }


### PR DESCRIPTION
### Related issues

https://github.com/Orange-OpenSource/ods-charts/issues/771

### Description

The merge of data options in theme options needed array to be merged in order to keep serie specifities in resulting charts options.

But when array merge is used for theme colors array, some of the default unused colors of the initial ODS project object was kept if the theme colors set had a length less than 5.

Decision :
- remove unused colors of the initial ODS project object
- make two methods to differ the developer use case :
  - mergeObjectsAndArrays : used when both arrays data of the source object and merged object must be kept
  - mergeObjectsAndReplaceArrays : used when arrays of the merged object must replace arrays of source object
- add unit test for both methods


### Motivation & Context

Limit theme color set to the selected set.

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Test checklist

Please check that the following tests projects are still working:

- [X] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [ ] `test/angular-ng-boosted`
- [ ] `test/angular-echarts`
- [ ] `test/angular-14`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`
- [ ] `test/examples/timeseries-chart`
