### PR TITLE
fix(lib): Error are displayed in the console when displaying a tooltip over the graph for an undefined item value

### DIFF
--- a/src/theme/popover/ods-chart-popover.ts
+++ b/src/theme/popover/ods-chart-popover.ts
@@ -263,12 +263,7 @@ export class ODSChartsPopover {
             return element;
           }
         )
-        .filter((elt) => {
-          if (undefined === elt.itemValue) {
-            console.error('failed displaying', elt);
-          }
-          return undefined !== elt.itemValue;
-        }),
+        .filter((elt) => undefined !== elt.itemValue),
     };
   }
 


### PR DESCRIPTION
### Related issues

https://github.com/Orange-OpenSource/ods-charts/issues/621

### Description

Remove the error console log. We consider a serie may contain an undefined value

### Motivation & Context

Remove error logs in console for normal use case

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Test checklist

Please check that the following tests projects are still working:

- [X] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [ ] `test/angular-ng-boosted`
- [ ] `test/angular-echarts`
- [ ] `test/angular-14`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`
- [ ] `test/examples/timeseries-chart`
