### PR TITLE
fix(lib): Legend invisible in case of dark mode with ODS Charts embedded

### DIFF
--- a/src/theme/legends/ods-chart-legends.ts
+++ b/src/theme/legends/ods-chart-legends.ts
@@ -35,8 +35,7 @@ const DEFAULT_CSS = `.ods-charts-no-css-lib.ods-charts-legend-holder {
   margin-right: 30px;
 }
 
-.ods-charts-no-css-lib .ods-charts-legend-item {
-  
+.ods-charts-no-css-lib .ods-charts-legend-item {  
   padding-bottom: 0.625rem;
   margin-right: 10px;
   margin-left: 10px;
@@ -74,17 +73,20 @@ const DEFAULT_CSS = `.ods-charts-no-css-lib.ods-charts-legend-holder {
   line-height: 16px;
 }
 
-[data-bs-theme="dark"] .ods-charts-no-css-lib.ods-charts-legend-holder {
-  background-color: var(--bs-gray-950, #141414);
+[data-bs-theme="dark"] {
+  --ods-charts-legend-bg: var(--bs-gray-950, #141414);
+  --ods-charts-legend-color: var(--bs-white, #fff);
 }
-[data-bs-theme="dark"] .ods-charts-no-css-lib.ods-charts-legend-holder .ods-charts-legend-item {
-  color: var(--bs-white, #fff);
+[data-bs-theme="light"] {
+  --ods-charts-legend-bg: var(--bs-white, #fff);
+  --ods-charts-legend-color: var(--bs-black, #000);
 }
-[data-bs-theme="light"] .ods-charts-no-css-lib.ods-charts-legend-holder {
-  background-color: var(--bs-white, #fff);
+
+.ods-charts-no-css-lib.ods-charts-legend-holder {
+  background-color: var(--ods-charts-legend-bg, var(--bs-body-bg, #ffffff));
 }
-[data-bs-theme="light"] .ods-charts-no-css-lib.ods-charts-legend-holder .ods-charts-legend-item {
-  color: var(--bs-black, #000);
+.ods-charts-no-css-lib.ods-charts-legend-holder .ods-charts-legend-item {
+  color: var(--ods-charts-legend-color, var(--bs-body-color, #000000));
 }
 `;
 


### PR DESCRIPTION
### Related issues

https://github.com/Orange-OpenSource/ods-charts/issues/768

### Description

In case of ODS Charts embedded css, light theme mode is defined after dark theme mode and in some use case it defined the priority of the rules.

This PR fix the bug by using `ods-charts-legend-bg` and `ods-charts-legend-color` css vars  to solve the issue.

### Motivation & Context

Fix the bug as descriped in the relative issue

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Test checklist

- [X] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [ ] `test/angular-ng-boosted`
- [ ] `test/angular-echarts`
- [ ] `test/angular-14`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`
- [ ] `test/examples/timeseries-chart`
