### PR TITLE
fix(colors): apply css var to :root

### DIFF
--- a/src/theme/colors/_ouds-colors-css-variables.ts
+++ b/src/theme/colors/_ouds-colors-css-variables.ts
@@ -7,7 +7,7 @@
 //
 
 export const ODS_CHARTS_CONTEXT = `
-:host, [data-bs-theme=light] {
+:root, :host, [data-bs-theme=light] {
   --ouds-charts-color-border: #ffffff;
   --ouds-charts-color-border-contrast: #ffffff;
   --ouds-charts-color-categorical-tier-1: #5b2f98;

--- a/src/theme/css-themes/css-variables.ts
+++ b/src/theme/css-themes/css-variables.ts
@@ -185,7 +185,7 @@ export const BOOSTED5_THEME_SPECIFIC_VARIABLES = `
  * Added for all themes
  */
 const ALL_THEMES_SPECIFIC_VARIABLES = `
-:host, [data-bs-theme=light] {
+:root, :host, [data-bs-theme=light] {
   --ods-charts-blue: #4170d8;
   --ods-charts-indigo: #a885d8;
   --ods-charts-purple: #a885d8;
@@ -260,7 +260,7 @@ const ALL_THEMES_SPECIFIC_VARIABLES = `
   --ods-charts-tertiary-bg: #000;
 }
 
-:host, [data-bs-theme="light"] {
+:root, :host, [data-bs-theme="light"] {
   --ods-yellow-100: #fff6b6;
   --ods-yellow-200: #ffe45b;
   --ods-yellow-300: #ffd200;


### PR DESCRIPTION
### Related issues

Not created

### Description

Next to commit `feat(colors): refactoring of css light and dark var defintion (#806)`
https://github.com/Orange-OpenSource/ods-charts/pull/806

The css var was created in :host, :root was missing

You can see missing css var in console logs

### Motivation & Context

Need to define css var in :root

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Test checklist

Please check that the following tests projects are still working:

- [X] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [ ] `test/angular-ng-boosted`
- [ ] `test/angular-echarts`
- [ ] `test/angular-14`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`
- [ ] `test/examples/timeseries-chart`
