### PR TITLE
fix(lib): Change Y and X axis display and line thickness of the lincharts according to last Orange Unified System

### DIFF
--- a/docs/static/[version]/examples.js
+++ b/docs/static/[version]/examples.js
@@ -835,7 +835,7 @@ window.generateTimeSeriesLineChart = async (id) => {
     for (var i = 1; i < NB_POINTS; i++) {
       data.push({
         time: dataDates[i],
-        value: Math.random() < 0.3 ? undefined : Math.round((Math.random() - 0.5) * 20 + lastValue),
+        value: Math.random() < 0.3 ? undefined : Math.max(0, Math.round((Math.random() - 0.5) * 20 + lastValue)),
       });
       lastValue = undefined !== data[data.length - 1].value ? data[data.length - 1].value : lastValue;
     }

--- a/src/theme/ODS.project.ts
+++ b/src/theme/ODS.project.ts
@@ -165,7 +165,8 @@ export interface EChartsProject {
       };
     };
     axisTick: {
-      show: false;
+      show: true;
+      alignWithLabel: true;
       lineStyle: {
         color: string;
       };
@@ -196,6 +197,7 @@ export interface EChartsProject {
     };
     axisTick: {
       show: false;
+      alignWithLabel: true;
       lineStyle: {
         color: string;
       };
@@ -205,7 +207,7 @@ export interface EChartsProject {
       color: string;
     };
     splitLine: {
-      show: false;
+      show: true;
       lineStyle: {
         color: string[];
       };
@@ -226,6 +228,7 @@ export interface EChartsProject {
     };
     axisTick: {
       show: false;
+      alignWithLabel: true;
       lineStyle: {
         color: string;
       };
@@ -255,7 +258,8 @@ export interface EChartsProject {
       };
     };
     axisTick: {
-      show: false;
+      show: true;
+      alignWithLabel: true;
       lineStyle: {
         color: string;
       };
@@ -416,7 +420,7 @@ export const ODS_PROJECT: EChartsProject = {
       borderWidth: 1,
     },
     lineStyle: {
-      width: 2,
+      width: 3,
     },
     symbolSize: 0,
     symbol: 'emptyCircle',
@@ -555,7 +559,8 @@ export const ODS_PROJECT: EChartsProject = {
       },
     },
     axisTick: {
-      show: false,
+      show: true,
+      alignWithLabel: true,
       lineStyle: {
         color: 'var(--bs-danger, #eb0909)',
       },
@@ -586,6 +591,7 @@ export const ODS_PROJECT: EChartsProject = {
     },
     axisTick: {
       show: false,
+      alignWithLabel: true,
       lineStyle: {
         color: 'var(--secondary-color, #6E7079)',
       },
@@ -595,7 +601,7 @@ export const ODS_PROJECT: EChartsProject = {
       color: 'var(--bs-body-color, #000000)',
     },
     splitLine: {
-      show: false,
+      show: true,
       lineStyle: {
         color: ['var(--bs-border-color-subtle, #cccccc)'],
       },
@@ -616,6 +622,7 @@ export const ODS_PROJECT: EChartsProject = {
     },
     axisTick: {
       show: false,
+      alignWithLabel: true,
       lineStyle: {
         color: 'var(--bs-secondary-color, #6E7079)',
       },
@@ -645,7 +652,8 @@ export const ODS_PROJECT: EChartsProject = {
       },
     },
     axisTick: {
-      show: false,
+      show: true,
+      alignWithLabel: true,
       lineStyle: {
         color: 'var(--bs-border-color-subtle, #cccccc)',
       },

--- a/src/theme/ods-chart-theme.ts
+++ b/src/theme/ods-chart-theme.ts
@@ -677,35 +677,29 @@ export class ODSChartsTheme {
         fontWeight: 'var(--bs-body-font-weight, 400)',
         fontSize: 14,
         fontFamily: 'Helvetica Neue, sans-serif',
-        color:
-          ODSChartsMode.DEFAULT === this.options.mode
-            ? 'var(--bs-body-color, #000)'
-            : ODSChartsMode.LIGHT === this.options.mode
-              ? 'var(--bs-black, #000)'
-              : 'var(--bs-white, #fff)',
+        color: 'var(--bs-body-color, #000)',
       };
       const axisLine = {
         show: true,
         lineStyle: {
           width: 2,
-          color:
-            ODSChartsMode.DEFAULT === this.options.mode
-              ? 'var(--bs-border-color-subtle, #ccc)'
-              : ODSChartsMode.LIGHT === this.options.mode
-                ? 'var(--bs-gray-500, #ccc)'
-                : 'var(--bs-gray-700, #666)',
+          color: 'var(--bs-border-color-subtle, #ccc)',
         },
       };
       const splitLine = {
         show: true,
         lineStyle: {
           width: 1,
-          color:
-            ODSChartsMode.DEFAULT === this.options.mode
-              ? 'var(--bs-border-color-subtle, #ccc)'
-              : ODSChartsMode.LIGHT === this.options.mode
-                ? 'var(--bs-gray-500, #ccc)'
-                : 'var(--bs-gray-700, #666)',
+          color: 'var(--bs-border-color-subtle, #ccc)',
+        },
+      };
+      const axisTick = {
+        show: true,
+        alignWithLabel: true,
+        length: 8,
+        lineStyle: {
+          width: 1,
+          color: 'var(--bs-border-color-subtle, #ccc)',
         },
       };
 
@@ -764,11 +758,20 @@ export class ODSChartsTheme {
 
       for (const axis of ['xAxis', 'yAxis']) {
         if (!isMainAxis(updatedDataOptionsForTheme[axis]) && !(updatedDataOptionsForTheme[axis] && updatedDataOptionsForTheme[axis].axisLine)) {
+          // We configure a value axis with no line, no split but keeping the label and the split
           themeOptions[axis].axisLine = { show: false };
-          themeOptions[axis].splitLine = { show: false };
-        } else {
-          themeOptions[axis].axisLine = cloneDeepObject(axisLine);
           themeOptions[axis].splitLine = cloneDeepObject(splitLine);
+          themeOptions[axis].axisTick = { show: false };
+        } else {
+          // For categorical and time axis, we do not display split lines but keep axis line.
+          themeOptions[axis].axisLine = cloneDeepObject(axisLine);
+          themeOptions[axis].splitLine = { show: false };
+          // we also display ticks if we display only line
+          if (this.dataOptions.series?.every((serie: any) => serie.type === 'line')) {
+            themeOptions[axis].axisTick = cloneDeepObject(axisTick);
+          } else {
+            themeOptions[axis].axisTick = { show: false };
+          }
         }
       }
 


### PR DESCRIPTION
### Related issues

https://github.com/Orange-OpenSource/ods-charts/issues/869

### Description

Change Y and X axis display and line thickness of the lincharts according to last Orange Unified System

### Motivation & Context

Cf issue https://github.com/Orange-OpenSource/ods-charts/issues/869

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Test checklist

Please check that the following tests projects are still working:

- [X] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [ ] `test/angular-ng-boosted`
- [ ] `test/angular-echarts`
- [ ] `test/angular-14`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`
- [ ] `test/examples/timeseries-chart`
