### PR TITLE
fix(lib): Wrong marker color

### DIFF
--- a/specs/spec-1062-wrong-marker-color.md
+++ b/specs/spec-1062-wrong-marker-color.md
@@ -1,0 +1,127 @@
+# spec-1062 — Wrong marker color
+
+**Issue:** [#1062 Wrong marker color](https://github.com/Orange-OpenSource/ods-charts/issues/1062)  
+**Component:** `ODSChartTheme` — `sliceColor()` / `getDisplayedColors()`  
+**Status:** Open
+
+---
+
+## Background
+
+The public methods `getSeriesColor(seriesIndex)`, `getLegendMarker(seriesIndex)` and `getPopoverMarker(seriesIndex)` return a series color from the internal `displayedColors` array.
+
+That array is built by `getDisplayedColors()`, which calls `sliceColor()` whenever a series has a specific color set via `lineStyle.color`, `itemStyle.color` or `color`.
+
+---
+
+## Problem
+
+### Current behaviour of `sliceColor()`
+
+```ts
+private sliceColor(colors: string[], color: string, seriesIndex: number) {
+  const previousColorIndex = colors.indexOf(color);
+  if (previousColorIndex > -1) {
+    colors.splice(previousColorIndex, 1); // ← removes the existing occurrence
+  }
+  colors.splice(seriesIndex, 0, color);  // ← inserts at the target index
+}
+```
+
+When a color `C` is already present in `colors` at index `i < seriesIndex`, the method **removes** it before inserting it at `seriesIndex`.  
+This shifts every element between `i` and `seriesIndex` one position to the left, corrupting the colors of all series whose indexes fall in that range.
+
+### Reproducible scenario
+
+A bar + line chart with:
+
+| Series | Type | Specified color               |
+| ------ | ---- | ----------------------------- |
+| 0      | bar  | orange (palette)              |
+| 1      | bar  | blue (palette)                |
+| 2      | line | **orange** (same as series 0) |
+
+Steps inside `getDisplayedColors()`:
+
+1. Initial `colors` = `[orange, blue, green, …]`
+2. Series 2 requests `orange` → `sliceColor(colors, 'orange', 2)`
+3. `indexOf('orange')` = **0** (< 2) → `splice(0, 1)` removes orange at index 0
+4. `colors` becomes `[blue, green, …]`
+5. `splice(2, 0, 'orange')` inserts → `colors` = `[blue, green, orange, …]`
+
+Result: `getSeriesColor(0)` now returns `blue` instead of `orange`.  
+→ `getLegendMarker(0)` and `getPopoverMarker(0)` display the wrong color for series 0.
+
+---
+
+## Fix specification
+
+### Rule
+
+`sliceColor()` **must not remove** the existing occurrence of the color when it is located at an index **lower than** `seriesIndex` (i.e. it has already been assigned to a previously processed series).
+
+It is perfectly valid for the same color to appear more than once in `displayedColors` — two series may intentionally share the same color.
+
+### Expected behaviour after the fix
+
+| Condition on `previousColorIndex` | Action                                                             |
+| --------------------------------- | ------------------------------------------------------------------ |
+| Not found (`-1`)                  | Insert at `seriesIndex` (unchanged)                                |
+| `>= seriesIndex`                  | Remove the occurrence, then insert at `seriesIndex` (unchanged)    |
+| `< seriesIndex`                   | **Do not remove** the occurrence; insert directly at `seriesIndex` |
+
+### Fix pseudo-code
+
+```ts
+private sliceColor(colors: string[], color: string, seriesIndex: number) {
+  const previousColorIndex = colors.indexOf(color);
+  if (previousColorIndex > -1 && previousColorIndex >= seriesIndex) {
+    // The occurrence exists at an index >= seriesIndex:
+    // remove it to avoid a visible duplicate downstream.
+    colors.splice(previousColorIndex, 1);
+  }
+  // If previousColorIndex < seriesIndex, do nothing:
+  // the color is legitimately used by an earlier series.
+  colors.splice(seriesIndex, 0, color);
+}
+```
+
+---
+
+## Test cases
+
+### TC-1 — Color shared between an earlier and a later series
+
+- **Setup:** 3 series — series 0 (bar, color `C`), series 2 (line, color `C`).
+- **Expected:** `getSeriesColor(0)` = `C`, `getSeriesColor(2)` = `C`.
+- **Before fix:** `getSeriesColor(0)` ≠ `C`.
+
+### TC-2 — Unique specific color (existing behaviour preserved)
+
+- **Setup:** Series 1 has a specific color `C` not present in the palette at indexes 0, 2, 3.
+- **Expected:** `getSeriesColor(1)` = `C`; other series keep their palette colors.
+
+### TC-3 — Specific color that matches a later palette entry (existing behaviour preserved)
+
+- **Setup:** Series 0 has color `C`; series 2 would have received `C` from the palette.
+- **Expected:** `getSeriesColor(0)` = `C`; the palette color at index 2 is shifted (already correct).
+
+### TC-4 — `getLegendMarker` / `getPopoverMarker` consistent with `getSeriesColor`
+
+- For every `seriesIndex`, the marker color returned by `getLegendMarker(i)` and `getPopoverMarker(i)` must match `getSeriesColor(i)`.
+
+---
+
+## Impacted files
+
+| File                                                      | Change                      |
+| --------------------------------------------------------- | --------------------------- |
+| `src/theme/ods-chart-theme.ts`                            | Fix `sliceColor()`          |
+| `src/theme/ods-chart-theme.spec.ts` (to create or extend) | Add test cases TC-1 to TC-4 |
+
+---
+
+## References
+
+- [Stackblitz — reduced test case](https://stackblitz.com/edit/is2p8s3d?file=index.js,index.html)
+- [GitHub issue #1062](https://github.com/Orange-OpenSource/ods-charts/issues/1062)

--- a/specs/spec-1062-wrong-marker-color.md
+++ b/specs/spec-1062-wrong-marker-color.md
@@ -1,7 +1,7 @@
 # spec-1062 — Wrong marker color
 
 **Issue:** [#1062 Wrong marker color](https://github.com/Orange-OpenSource/ods-charts/issues/1062)  
-**Component:** `ODSChartTheme` — `sliceColor()` / `getDisplayedColors()`  
+**Component:** `ODSChartsTheme` — `sliceColor()` / `getDisplayedColors()`  
 **Status:** Open
 
 ---

--- a/src/theme/ods-chart-theme.spec.ts
+++ b/src/theme/ods-chart-theme.spec.ts
@@ -1,0 +1,128 @@
+//
+// Software Name: Orange Design System Charts
+// SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license.
+//
+
+// CRITICAL: Setup DOM BEFORE any imports
+const { JSDOM } = require('jsdom');
+const dom = new JSDOM('<!DOCTYPE html><html><head></head><body></body></html>');
+
+Object.defineProperty(globalThis, 'window', { value: dom.window, writable: true });
+Object.defineProperty(globalThis, 'document', { value: dom.window.document, writable: true });
+Object.defineProperty(globalThis, 'navigator', { value: dom.window.navigator, writable: true });
+(globalThis as any).HTMLElement = dom.window.HTMLElement;
+(globalThis as any).Element = dom.window.Element;
+
+import 'jasmine';
+import { ODSChartsTheme } from './ods-chart-theme';
+
+describe('ODSChartsTheme.getSeriesColor', () => {
+  // Baseline palette colors captured once with no dataOptions.
+  let paletteColors: string[];
+
+  beforeAll(() => {
+    paletteColors = [...ODSChartsTheme.getThemeManager().displayedColors];
+  });
+
+  describe('TC-1 — color shared between an earlier and a later series (bug #1062)', () => {
+    // Before the fix, sliceColor() removed the occurrence at index 0 when
+    // processing series 2, shifting every intermediate color and corrupting series 0.
+
+    it('should keep the correct color for series 0 when series 2 shares the same itemStyle color', () => {
+      const COLOR = '#abcdef';
+      const tm = ODSChartsTheme.getThemeManager();
+      tm.setDataOptions({
+        series: [
+          { itemStyle: { color: COLOR } }, // series 0: specific color C
+          {}, // series 1: palette color
+          { itemStyle: { color: COLOR } }, // series 2: same specific color C
+        ],
+      });
+      expect(tm.getSeriesColor(0)).toBe(COLOR);
+      expect(tm.getSeriesColor(2)).toBe(COLOR);
+    });
+
+    it('should keep the correct color for series 0 when series 2 shares the same lineStyle color', () => {
+      const COLOR = '#abcdef';
+      const tm = ODSChartsTheme.getThemeManager();
+      tm.setDataOptions({
+        series: [
+          { lineStyle: { color: COLOR } }, // series 0
+          {}, // series 1
+          { lineStyle: { color: COLOR } }, // series 2
+        ],
+      });
+      expect(tm.getSeriesColor(0)).toBe(COLOR);
+      expect(tm.getSeriesColor(2)).toBe(COLOR);
+    });
+
+    it('should not corrupt series 1 color when series 0 and series 2 share a color', () => {
+      const COLOR = '#112233';
+      const tm = ODSChartsTheme.getThemeManager();
+      tm.setDataOptions({
+        series: [{ itemStyle: { color: COLOR } }, {}, { itemStyle: { color: COLOR } }, {}],
+      });
+      expect(tm.getSeriesColor(0)).toBe(COLOR);
+      expect(tm.getSeriesColor(2)).toBe(COLOR);
+      expect(tm.getSeriesColor(1)).not.toBe(COLOR);
+      expect(tm.getSeriesColor(3)).not.toBe(COLOR);
+    });
+  });
+
+  describe('TC-2 — unique specific color (existing behaviour preserved)', () => {
+    it('should assign a unique specific color to series 1 without affecting surrounding series', () => {
+      const COLOR = '#fedcba'; // value that does not appear in the default palette
+      const tm = ODSChartsTheme.getThemeManager();
+      tm.setDataOptions({
+        series: [
+          {}, // series 0: palette
+          { itemStyle: { color: COLOR } }, // series 1: specific color
+          {}, // series 2: palette
+        ],
+      });
+      expect(tm.getSeriesColor(0)).toBe(paletteColors[0]);
+      expect(tm.getSeriesColor(1)).toBe(COLOR);
+    });
+  });
+
+  describe('TC-3 — specific color matching a later palette entry (existing behaviour preserved)', () => {
+    it('should remove the later-index palette occurrence and not assign it to series 2', () => {
+      // paletteColors[2] naturally sits at index 2.
+      // When series 0 is explicitly assigned that color, sliceColor() should
+      // remove it from index 2 (>= seriesIndex 0) so that series 2 no longer
+      // receives the same color as series 0.
+      const COLOR = paletteColors[2];
+      const tm = ODSChartsTheme.getThemeManager();
+      tm.setDataOptions({
+        series: [
+          { itemStyle: { color: COLOR } }, // series 0 takes palette[2]
+          {},
+          {},
+        ],
+      });
+      expect(tm.getSeriesColor(0)).toBe(COLOR);
+      expect(tm.getSeriesColor(2)).not.toBe(COLOR);
+    });
+  });
+
+  describe('TC-4 — getSeriesColor consistency with marker helpers', () => {
+    it('should return a stable and correct color for each series index', () => {
+      // getLegendMarker/getPopoverMarker both delegate to getSeriesColor internally.
+      // Verifying that getSeriesColor is stable ensures that any caller (including
+      // markers) receives the correct color.
+      const COLOR = '#aabbcc';
+      const tm = ODSChartsTheme.getThemeManager();
+      tm.setDataOptions({
+        series: [{ itemStyle: { color: COLOR } }, {}, { itemStyle: { color: COLOR } }],
+      });
+      expect(tm.getSeriesColor(0)).toBe(tm.getSeriesColor(0));
+      expect(tm.getSeriesColor(1)).toBe(tm.getSeriesColor(1));
+      expect(tm.getSeriesColor(2)).toBe(tm.getSeriesColor(2));
+      expect(tm.getSeriesColor(0)).toBe(COLOR);
+      expect(tm.getSeriesColor(2)).toBe(COLOR);
+    });
+  });
+});

--- a/src/theme/ods-chart-theme.spec.ts
+++ b/src/theme/ods-chart-theme.spec.ts
@@ -108,7 +108,7 @@ describe('ODSChartsTheme.getSeriesColor', () => {
     });
   });
 
-  describe('TC-4 — getSeriesColor consistency with marker helpers', () => {
+  describe('TC-4 — getSeriesColor stability for repeated calls', () => {
     it('should return a stable and correct color for each series index', () => {
       // getLegendMarker/getPopoverMarker both delegate to getSeriesColor internally.
       // Verifying that getSeriesColor is stable ensures that any caller (including

--- a/src/theme/ods-chart-theme.ts
+++ b/src/theme/ods-chart-theme.ts
@@ -44,7 +44,7 @@ import { DEFAULT_OUDS_COLORS_PINK } from './default/OUDS.colors.pink';
 import { DEFAULT_OUDS_COLORS_PURPLE } from './default/OUDS.colors.purple';
 import { DEFAULT_OUDS_COLORS_SINGLE } from './default/OUDS.colors.single';
 import { DEFAULT_OUDS_COLORS_YELLOW } from './default/OUDS.colors.yellow';
-import { ODSChartsConfiguration } from '../ods-charts';
+import { ODSChartsConfiguration } from './charts-type/charts-type';
 import { mergeObjectsAndArrays, mergeObjectsAndReplaceArrays } from '../tools/merge-objects';
 // import { DEFAULT_OUDS_COMMON } from './default/OUDS.common'; // TODO: use when we can switch between ODS and OUDS
 // import { DEFAULT_OUDS_LINES_AXIS } from './default/OUDS.lines.axis';

--- a/src/theme/ods-chart-theme.ts
+++ b/src/theme/ods-chart-theme.ts
@@ -505,7 +505,10 @@ export class ODSChartsTheme {
 
   private sliceColor(colors: string[], color: string, seriesIndex: number) {
     const previousColorIndex = colors.indexOf(color);
-    if (previousColorIndex > -1) {
+    if (previousColorIndex > -1 && previousColorIndex >= seriesIndex) {
+      // Only remove the existing occurrence when it sits at or after seriesIndex.
+      // If it sits before seriesIndex the color is legitimately owned by an earlier
+      // series and removing it would shift all intermediate colors incorrectly.
       colors.splice(previousColorIndex, 1);
     }
     colors.splice(seriesIndex, 0, color);


### PR DESCRIPTION

### Related issues

https://github.com/Orange-OpenSource/ods-charts/issues/1062

### Description

The utility method providing the marker’s HTML code can return a wrong-color marker if several series are of the same color.

This can be the case in a bar and line charts if the line has the same color of a bar, only one serie will keep the specific color and other colors may be wrong.

In ODSChartTheme, sliceColor() should note remove the color from the list if it is already used in an index previous from the current one (and then keep the color twice)

Removing the color in a preivous index, all the already calculated color index between the previous index and the current index will be wrongly shifted

### Motivation & Context

Fix bug

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Test checklist

Please check that the following tests projects are still working:

- [ ] `docs/examples`
- [ ] `test/angular-ngx-echarts`
- [ ] `test/angular-ng-boosted`
- [ ] `test/angular-echarts`
- [ ] `test/angular-14`
- [ ] `test/html`
- [ ] `test/react`
- [ ] `test/vue`
- [ ] `test/examples/bar-line-chart`
- [ ] `test/examples/single-line-chart`
- [ ] `test/examples/timeseries-chart`
